### PR TITLE
Fix #2: link references, footnotes

### DIFF
--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -6,7 +6,8 @@ use genemichaels::{
 };
 
 fn rt(text: &str) {
-    assert_eq!(text, &format_str(text, &FormatConfig::default()).unwrap().rendered);
+    let after = format_str(text, &FormatConfig::default()).unwrap().rendered;
+    assert!(text == &after, "Roundtrip changes\n\nBefore:\n{}\n\nAfter:\n{}", text, &after);
 }
 
 #[test]
@@ -15,4 +16,27 @@ fn rt_macro1() {
     log!($l, slog::Level::Error, "", $($args) *)
 };);
 "#);
+}
+
+#[test]
+fn rt_comment_footnote1() {
+    rt(
+        r#"//! If that's what you have and it works, you don't need this crate at all — you
+//! can just use [`CARGO_BIN_EXE_<name>`][cargo-env].
+//!
+//!   [cargo-env]: https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-crates
+pub struct Foo;
+
+impl Foo {
+    pub fn do_stuff() {
+        fn get_cargo_env_or_panic(key: &str) -> std::ffi::OsString {
+            std::env::var_os(key).unwrap_or_else(||
+                panic!("The environment variable '{key}' is not set, is this running under a 'cargo test' command?")
+            )
+        }
+
+        get_cargo_env_or_panic("");
+    }
+}"#,
+    );
 }


### PR DESCRIPTION
For reference, pulldown_cmark with the input
```
[link 1](https://link)

[link 2][ref]

[link 3][]

<https://website>

[^1]

<abcd@example.com>

[ref]: https://example.corn
[link 3]: https://collapsed

[^1]: footty

```

Produces this event stream
```
Start(Paragraph)
    Start(Link(Inline, Borrowed("https://link"), Borrowed("")))
        Text(Borrowed("link 1"))
        End(Link(Inline, Borrowed("https://link"), Borrowed("")))
    End(Paragraph)
Start(Paragraph)
    Start(Link(Reference, Borrowed("https://example.corn"), Borrowed("")))
        Text(Borrowed("link 2"))
        End(Link(Reference, Borrowed("https://example.corn"), Borrowed("")))
    End(Paragraph)
Start(Paragraph)
    Start(Link(Collapsed, Borrowed("https://collapsed"), Borrowed("")))
        Text(Borrowed("link 3"))
        End(Link(Collapsed, Borrowed("https://collapsed"), Borrowed("")))
    End(Paragraph)
Start(Paragraph)
    Start(Link(Autolink, Borrowed("https://website"), Borrowed("")))
        Text(Borrowed("https://website"))
        End(Link(Autolink, Borrowed("https://website"), Borrowed("")))
    End(Paragraph)
Start(Paragraph)
    FootnoteReference(Borrowed("1"))
    End(Paragraph)
Start(Paragraph)
    Start(Link(Email, Borrowed("abcd@example.com"), Borrowed("")))
        Text(Borrowed("abcd@example.com"))
        End(Link(Email, Borrowed("abcd@example.com"), Borrowed("")))
    End(Paragraph)
Start(FootnoteDefinition(Borrowed("1")))
    Start(Paragraph)
        Text(Borrowed("footty"))
        End(Paragraph)
    End(FootnoteDefinition(Borrowed("1")))
```

`ref` is lost for link references

Upstream issue: https://github.com/raphlinus/pulldown-cmark/issues/434