### PR TITLE
Fix #3: Simple struct remainder

### DIFF
--- a/src/sg_expr.rs
+++ b/src/sg_expr.rs
@@ -731,6 +731,7 @@ impl Formattable for &Expr {
                     for pair in e.fields.pairs() {
                         if i > 0 {
                             sg.seg(out, ",");
+                            sg.seg_unsplit(out, " ");
                         }
                         sg.split(out, indent.clone(), true);
                         match &pair.value().member {
@@ -741,17 +742,19 @@ impl Formattable for &Expr {
                             syn::Member::Unnamed(_) => unreachable!(),
                         };
                         sg.child(pair.value().expr.make_segs(out, &indent));
-                        sg.seg_unsplit(out, " ");
                         i += 1;
                     }
-                    if let Some(rem) = &e.rest {
+                    if let Some(dots) = &e.dot2_token {
                         if i > 0 {
                             sg.seg(out, ",");
                             sg.seg_unsplit(out, " ");
-                            sg.split(out, indent.clone(), true);
                         }
+                        sg.split(out, indent.clone(), true);
+                        append_comments(out, base_indent, &mut sg, dots.spans[0].start());
                         sg.seg(out, "..");
-                        sg.child(rem.make_segs(out, &indent));
+                        if let Some(rem) = &e.rest {
+                            sg.child(rem.make_segs(out, &indent));
+                        }
                         sg.seg_unsplit(out, " ");
                     } else {
                         sg.seg_split(out, ",");

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -16,3 +16,18 @@ fn rt_macro1() {
 };);
 "#);
 }
+
+#[test]
+fn rt_macro2() {
+    rt(
+        r#"struct Foo {
+    yes: bool,
+    other: i32,
+}
+
+fn g(f: Foo) {
+    assert!(matches!(f, Foo { yes: yes, .. } if yes))
+}
+"#,
+    );
+}


### PR DESCRIPTION
The case of `..` without a following expr wasn't handled, added.