### PR TITLE
Added Clippy `#[allow()]` and fixed other lints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,9 +16,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "cc"
-version = "1.0.77"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f73505338f7d905b19d18738976aae232eb46b8efc15554ffc56deb5d9ebe4"
+checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
 
 [[package]]
 name = "cfg-if"
@@ -142,9 +142,9 @@ checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f9f08d8963a6c613f4b1a78f4f4a4dbfadf8e6545b2d72861731e4858b8b47f"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "litrs"
@@ -245,9 +245,9 @@ checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
 name = "rustix"
-version = "0.36.4"
+version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb93e85278e08bb5788653183213d3a60fc242b10cb9be96586f5a73dcb67c23"
+checksum = "a3807b5d10909833d3e9acd1eb5fb988f79376ff10fce42937de71a449c4c588"
 dependencies = [
  "bitflags",
  "errno",
@@ -316,9 +316,9 @@ checksum = "d70b6494226b36008c8366c288d77190b3fad2eb4c10533139c1c1f461127f1a"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,15 +4,9 @@ version = 3
 
 [[package]]
 name = "anyhow"
-version = "1.0.66"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
-
-[[package]]
-name = "autocfg"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "2cb2f989d18dd141ab8ae82f64d1a8cdd37e0840f73a406896cf5e99502fab61"
 
 [[package]]
 name = "bitflags"
@@ -70,23 +64,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "displaydoc"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bf95dc3f046b9da4f2d51833c0d3547d8564ef6910f5c1ed130306a75b92886"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "either"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
-
-[[package]]
 name = "errno"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -108,24 +85,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "fixed_decimal"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f6fa77730b2c921549ccecf3ad7b0ce0fb14481d47fad0c358addc4aeb456a"
-dependencies = [
- "displaydoc",
- "smallvec",
- "writeable",
-]
-
-[[package]]
 name = "genemichaels"
 version = "0.1.11"
 dependencies = [
  "anyhow",
  "clap",
- "icu_segmenter",
- "icu_testdata",
  "markdown",
  "proc-macro2",
  "quote",
@@ -146,269 +110,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "icu_calendar"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81b686a9fbeca17bfa11b5b9864d840d8f2dc5abd80bef562486a6005f62c248"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_provider",
- "tinystr",
- "writeable",
- "zerovec",
-]
-
-[[package]]
-name = "icu_collator"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9ca263b27af1ab7192837ebe4e5389d389d0c249885f65c9b330decfc3e4abb"
-dependencies = [
- "displaydoc",
- "icu_collections",
- "icu_locid",
- "icu_normalizer",
- "icu_properties",
- "icu_provider",
- "smallvec",
- "utf16_iter",
- "utf8_iter",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_collections"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5be938a104d76f3bb9be012b6cd1451f7ed61c1eb9605c80f0f59c23f204dd"
-dependencies = [
- "displaydoc",
- "serde",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_datetime"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9109c2277e98df5ebea10fa63cdd1aafbf78d726ecddbd205b8cff212345b98"
-dependencies = [
- "displaydoc",
- "either",
- "fixed_decimal",
- "icu_calendar",
- "icu_decimal",
- "icu_locid",
- "icu_plurals",
- "icu_provider",
- "icu_timezone",
- "litemap",
- "smallvec",
- "tinystr",
- "writeable",
- "zerovec",
-]
-
-[[package]]
-name = "icu_decimal"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d36aab31559864247be8b5c11a0a00a649c15922bfe158442b9083e78d8c1fc3"
-dependencies = [
- "displaydoc",
- "fixed_decimal",
- "icu_locid",
- "icu_provider",
- "writeable",
-]
-
-[[package]]
-name = "icu_list"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c40218275f081c4493f190357c5395647b06734c2dc3dcb41cc099a0f60168b1"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_provider",
- "regex-automata",
- "writeable",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34b3de5d99a0e275fe6193b9586dbf37364daebc0d39c89b5cf8376a53b789e8"
-dependencies = [
- "displaydoc",
- "litemap",
- "serde",
- "tinystr",
- "writeable",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "934712cef692e652dbc9a02024c2fc7d82ac7c6406d84f482c8b6f52cc897273"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_normalizer"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f13202f9022ca7cf1b08631bc026526a1b232ceb70695ed5a7ffbb90a90c67e"
-dependencies = [
- "displaydoc",
- "icu_collections",
- "icu_properties",
- "icu_provider",
- "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_plurals"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e81bb05ec62d5103926407da9a366c2af53e3d3f3bd0b94cd7074510a74d7444"
-dependencies = [
- "displaydoc",
- "fixed_decimal",
- "icu_locid",
- "icu_provider",
- "zerovec",
-]
-
-[[package]]
-name = "icu_properties"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b46dce0df6daeda3aec068f6f31eeaa6402525a505df9b816d8fd5bd9c876448"
-dependencies = [
- "displaydoc",
- "icu_collections",
- "icu_provider",
- "zerovec",
-]
-
-[[package]]
-name = "icu_provider"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f911086e3c521a8a824d4f8bfd87769645ced2f07ff913b521c0d793be07100"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_provider_macros",
- "serde",
- "stable_deref_trait",
- "writeable",
- "yoke",
- "zerofrom",
- "zerovec",
-]
-
-[[package]]
-name = "icu_provider_adapters"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "980c71d8a91b246ebbb97847178a4b816eea39d1d550c70ee566384555bb6545"
-dependencies = [
- "icu_locid",
- "icu_provider",
- "tinystr",
- "yoke",
- "zerovec",
-]
-
-[[package]]
-name = "icu_provider_macros"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38cf6f5b65cf81f0b4298da647101acbfe6ae0e25263f92bd7a22597e9d6d606"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "icu_segmenter"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4873fb468f410f9a06b51bc0c1156084db6adb671923d5289ce42103a47bc796"
-dependencies = [
- "displaydoc",
- "icu_collections",
- "icu_locid",
- "icu_provider",
- "ndarray",
- "num-traits",
- "serde",
- "serde_json",
- "utf8_iter",
- "zerovec",
-]
-
-[[package]]
-name = "icu_testdata"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e03d02c963ad1f0680749016afad29f87933ca82957c536bfa975880b2efdae"
-dependencies = [
- "icu_calendar",
- "icu_collator",
- "icu_collections",
- "icu_datetime",
- "icu_decimal",
- "icu_list",
- "icu_locid",
- "icu_locid_transform",
- "icu_normalizer",
- "icu_plurals",
- "icu_properties",
- "icu_provider",
- "icu_provider_adapters",
- "icu_timezone",
- "litemap",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_timezone"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "081c60a92f80496fe2aa49a54ab86394ec2f91993cff985f8451e4912a347ea0"
-dependencies = [
- "displaydoc",
- "icu_calendar",
- "icu_locid",
- "icu_provider",
- "tinystr",
- "zerovec",
 ]
 
 [[package]]
@@ -434,12 +135,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itoa"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
-
-[[package]]
 name = "libc"
 version = "0.2.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -450,12 +145,6 @@ name = "linux-raw-sys"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f9f08d8963a6c613f4b1a78f4f4a4dbfadf8e6545b2d72861731e4858b8b47f"
-
-[[package]]
-name = "litemap"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f34a3f4798fac63fb48cf277eefa38f94d3443baff555bb98e4f56bc9092368e"
 
 [[package]]
 name = "litrs"
@@ -483,63 +172,6 @@ checksum = "e15a8b67b7a9cb4bfbda3131ab091529c338174c78da8d46adbce1e510daf191"
 dependencies = [
  "log",
  "unicode-id",
-]
-
-[[package]]
-name = "matrixmultiply"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add85d4dd35074e6fedc608f8c8f513a3548619a9024b751949ef0e8e45a4d84"
-dependencies = [
- "rawpointer",
-]
-
-[[package]]
-name = "memchr"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
-
-[[package]]
-name = "ndarray"
-version = "0.15.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb12d4e967ec485a5f71c6311fe28158e9d6f4bc4a447b474184d0f91a8fa32"
-dependencies = [
- "matrixmultiply",
- "num-complex",
- "num-integer",
- "num-traits",
- "rawpointer",
- "serde",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ae39348c8bc5fbd7f40c727a9925f03517afd2ab27d46702108b6a7e5414c19"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
-dependencies = [
- "autocfg",
- "num-traits",
-]
-
-[[package]]
-name = "num-traits"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
-dependencies = [
- "autocfg",
 ]
 
 [[package]]
@@ -580,27 +212,21 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "rawpointer"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "regex"
@@ -609,15 +235,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
 dependencies = [
  "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9368763f5a9b804326f3af749e16f9abf378d227bcdee7634b13d8f17793782"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -639,55 +256,6 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys",
 ]
-
-[[package]]
-name = "ryu"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
-
-[[package]]
-name = "serde"
-version = "1.0.149"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256b9932320c590e707b94576e3cc1f7c9024d0ee6612dfbcf1cb106cbe8e055"
-dependencies = [
- "serde_derive",
-]
-
-[[package]]
-name = "serde_derive"
-version = "1.0.149"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4eae9b04cbffdfd550eb462ed33bc6a1b68c935127d008b27444d08380f94e4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "serde_json"
-version = "1.0.89"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020ff22c755c2ed3f8cf162dbb41a7268d934702f3ed3631656ea597e08fc3db"
-dependencies = [
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "smallvec"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
-
-[[package]]
-name = "stable_deref_trait"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "strsim"
@@ -722,25 +290,13 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.105"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b9b43d45702de4c839cb9b51d9f529c5dd26a4aff255b42b1ebc03e88ee908"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "unicode-xid",
 ]
 
 [[package]]
@@ -750,17 +306,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "tinystr"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8aeafdfd935e4a7fe16a91ab711fa52d54df84f9c8f7ca5837a9d1d902ef4c2"
-dependencies = [
- "displaydoc",
- "serde",
- "zerovec",
 ]
 
 [[package]]
@@ -774,24 +319,6 @@ name = "unicode-ident"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
-
-[[package]]
-name = "utf16_iter"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52df8b7fb78e7910d776fccf2e42ceaf3604d55e8e7eb2dbd183cb1441d8a692"
-
-[[package]]
-name = "utf8_iter"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64a8922555b9500e3d865caed19330172cd67cbf82203f1a3311d8c305cc9f33"
 
 [[package]]
 name = "version_check"
@@ -886,84 +413,3 @@ name = "windows_x86_64_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
-
-[[package]]
-name = "write16"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
-
-[[package]]
-name = "writeable"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8e6ab4f5da1b24daf2c590cfac801bacb27b15b4f050e84eb60149ea726f06b"
-
-[[package]]
-name = "yoke"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fe1d55ca72c32d573bfbd5cb2f0ca65a497854c44762957a6d3da96041a5184"
-dependencies = [
- "serde",
- "stable_deref_trait",
- "yoke-derive",
- "zerofrom",
-]
-
-[[package]]
-name = "yoke-derive"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1346e4cd025ae818b88566eac7eb65ab33a994ea55f355c86889af2e7e56b14e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
-name = "zerofrom"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79e9355fccf72b04b7deaa99ce7a0f6630530acf34045391b74460fcd714de54"
-dependencies = [
- "zerofrom-derive",
-]
-
-[[package]]
-name = "zerofrom-derive"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e8aa86add9ddbd2409c1ed01e033cd457d79b1b1229b64922c25095c595e829"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
-name = "zerovec"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25931c326414781db3d859f6e341e5bba119a3eddb7c5ae9976fe0d703b2dd26"
-dependencies = [
- "serde",
- "yoke",
- "zerofrom",
- "zerovec-derive",
-]
-
-[[package]]
-name = "zerovec-derive"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490e5f878c2856225e884c35927e7ea6db3c24cdb7229b72542c7526ad7ed49e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,12 +8,14 @@ repository = "https://github.com/andrewbaxter/genemichaels"
 readme = "readme.md"
 
 [dependencies]
-anyhow = "1.0.66"
+anyhow = "1.0.68"
 clap = { version = "4.0.29", features = ["derive"] }
-icu_segmenter = { version = "0.7.0", features = ["lstm"] }
-icu_testdata = "1.0.0"
 markdown = "1.0.0-alpha.5"
-proc-macro2 = { version = "1.0.47", features = ["span-locations"] }
-quote = "1.0.21"
+proc-macro2 = { version = "1.0.49", features = ["span-locations"] }
+quote = "1.0.23"
 structre = "0.0.1"
-syn = { version = "1.0.105", features = ["full"] }
+syn = { version = "1.0.107", features = ["full"] }
+
+# UNUSED?
+# icu_segmenter = { version = "0.7.0", features = ["lstm"] }
+# icu_testdata = "1.0.0"

--- a/src/bin/genemichaels.rs
+++ b/src/bin/genemichaels.rs
@@ -80,7 +80,7 @@ fn main() {
 
         fn from_str(s: &str) -> Result<Self, Self::Err> {
             if s == "on" {
-                return Ok(On)
+                Ok(On)
             } else {
                 return Err(OnErr(format!("[{}] not allowed, must be on or off", s)))
             }
@@ -151,7 +151,7 @@ fn main() {
             return Err(
                 anyhow!(
                     "The following comments were missed during formatting: {:?}",
-                    res.lost_comments.values().flat_map(|x| x).collect::<Vec<&Comment>>()
+                    res.lost_comments.values().flatten().collect::<Vec<&Comment>>()
                 ),
             );
         }
@@ -198,7 +198,7 @@ fn main() {
     };
 
     fn skip(src: &str) -> bool {
-        (&src).lines().take(5).any(|l| l.contains("`nogenemichaels`"))
+        src.lines().take(5).any(|l| l.contains("`nogenemichaels`"))
     }
 
     if args.files.is_empty() {
@@ -231,7 +231,7 @@ fn main() {
                 }
                 eprintln!("Formatting {}", &file.to_string_lossy());
                 let out = process(&config, &source)?;
-                fs::write(&file, out.as_bytes())?;
+                fs::write(file, out.as_bytes())?;
                 Ok(())
             }) {
                 Ok(_) => { },

--- a/src/sg_expr.rs
+++ b/src/sg_expr.rs
@@ -53,6 +53,7 @@ enum DottedRes<'a> {
     Leaf(&'a Expr),
 }
 
+#[allow(clippy::needless_lifetimes)]
 fn get_dotted<'a>(e: &'a Expr) -> DottedRes<'a> {
     match e {
         Expr::Await(x) => DottedRes::Dotted(Dotted::Await(x)),
@@ -155,7 +156,7 @@ fn new_sg_dotted(out: &mut MakeSegsState, base_indent: &Alignment, root: Dotted)
             sg.child(build_child(out, &indent, &child));
         }
     } else {
-        sg.child(build_child(out, base_indent, &children.get(0).unwrap()));
+        sg.child(build_child(out, base_indent, children.get(0).unwrap()));
     }
     sg.build(out)
 }
@@ -351,22 +352,22 @@ impl Formattable for &Expr {
                         }
                         if e.asyncness.is_some() {
                             if need_space {
-                                prefix.push_str(" ");
+                                prefix.push(' ');
                             }
                             prefix.push_str("async");
                             need_space = true;
                         }
                         if e.capture.is_some() {
                             if need_space {
-                                prefix.push_str(" ");
+                                prefix.push(' ');
                             }
                             prefix.push_str("move");
                             need_space = true;
                         }
                         if need_space {
-                            prefix.push_str(" ");
+                            prefix.push(' ');
                         }
-                        prefix.push_str("|");
+                        prefix.push('|');
                         new_sg_bracketed_list_common(
                             out,
                             base_indent,
@@ -407,7 +408,7 @@ impl Formattable for &Expr {
                 |out: &mut MakeSegsState, _base_indent: &Alignment| {
                     let mut prefix = "continue".to_string();
                     if let Some(label) = &e.label {
-                        prefix.push_str(" ");
+                        prefix.push(' ');
                         prefix.push_str(&label.to_string());
                     }
                     let mut sg = new_sg(out);
@@ -590,7 +591,7 @@ impl Formattable for &Expr {
                         sg.child(
                             new_sg_outer_attrs(
                                 out,
-                                &base_indent,
+                                base_indent,
                                 &arm.attrs,
                                 |out: &mut MakeSegsState, base_indent: &Alignment| {
                                     let mut sg = new_sg(out);

--- a/src/sg_general.rs
+++ b/src/sg_general.rs
@@ -149,7 +149,7 @@ pub(crate) fn append_statement_list_raw(
             }
             sg.split(out, base_indent.clone(), true);
         }
-        sg.child((&el).make_segs(out, &base_indent));
+        sg.child((el).make_segs(out, base_indent));
         sg.seg_unsplit(out, " ");
         previous_margin_group = new_margin_group;
         i += 1;
@@ -260,7 +260,7 @@ pub(crate) fn append_macro_body_bracketed(
         syn::MacroDelimiter::Paren(x) => {
             sg.seg(out, "(");
             sg.split(out, indent.clone(), true);
-            append_macro_body(out, &indent, sg, tokens.clone());
+            append_macro_body(out, &indent, sg, tokens);
             append_comments(out, base_indent, sg, x.span.end().prev());
             sg.split(out, base_indent.clone(), false);
             sg.seg(out, ")");
@@ -269,7 +269,7 @@ pub(crate) fn append_macro_body_bracketed(
             sg.seg(out, "{");
             sg.initial_split();
             sg.split(out, indent.clone(), true);
-            append_macro_body(out, &indent, sg, tokens.clone());
+            append_macro_body(out, &indent, sg, tokens);
             append_comments(out, base_indent, sg, x.span.end().prev());
             sg.split(out, base_indent.clone(), false);
             sg.seg(out, "}");
@@ -277,7 +277,7 @@ pub(crate) fn append_macro_body_bracketed(
         syn::MacroDelimiter::Bracket(x) => {
             sg.seg(out, "[");
             sg.split(out, indent.clone(), true);
-            append_macro_body(out, &indent, sg, tokens.clone());
+            append_macro_body(out, &indent, sg, tokens);
             append_comments(out, base_indent, sg, x.span.end().prev());
             sg.split(out, base_indent.clone(), false);
             sg.seg(out, "]");
@@ -319,16 +319,10 @@ pub(crate) fn append_macro_body(
             let mut top = vec![];
             for t in tokens {
                 let (push, break_) = match &t {
-                    proc_macro2::TokenTree::Punct(p) if match p.as_char() {
-                        ';' | ',' => true,
-                        _ => false,
-                    } => {
+                    proc_macro2::TokenTree::Punct(p) if matches!(p.as_char(), ';' | ',') => {
                         (false, Some(Some(p.clone())))
                     },
-                    proc_macro2::TokenTree::Group(g) if match g.delimiter() {
-                        proc_macro2::Delimiter::Brace => true,
-                        _ => false,
-                    } => {
+                    proc_macro2::TokenTree::Group(g) if matches!(g.delimiter(), proc_macro2::Delimiter::Brace) => {
                         (true, Some(None))
                     },
                     _ => {

--- a/src/sg_general_lists.rs
+++ b/src/sg_general_lists.rs
@@ -50,8 +50,8 @@ pub(crate) fn append_inline_list_raw<
             sg.split(out, base_indent.clone(), true);
             sg.seg_unsplit(out, " ");
         }
-        sg.child(pair.value().make_segs(out, &base_indent));
-        next_punct = pair.punct().map(|p| *p);
+        sg.child(pair.value().make_segs(out, base_indent));
+        next_punct = pair.punct().copied();
     }
     match suffix {
         InlineListSuffix::None => { },
@@ -114,10 +114,7 @@ pub(crate) fn append_bracketed_list<
 ) {
     append_comments(out, base_indent, sg, prefix_start);
     sg.seg(out, prefix);
-    let need_pad = bracket_space && (!exprs.is_empty() || match &list_suffix {
-        InlineListSuffix::Extra(_) => true,
-        _ => false,
-    });
+    let need_pad = bracket_space && (!exprs.is_empty() || matches!(&list_suffix, InlineListSuffix::Extra(_)));
     if need_pad {
         sg.seg_unsplit(out, " ");
     }

--- a/src/sg_pat.rs
+++ b/src/sg_pat.rs
@@ -269,7 +269,7 @@ impl Formattable for FieldPat {
                     syn::Member::Named(x) => sg.seg(out, x),
                     syn::Member::Unnamed(x) => sg.seg(out, x.index),
                 };
-                append_comments(out, &base_indent, &mut sg, col.span.start());
+                append_comments(out, base_indent, &mut sg, col.span.start());
                 sg.seg(out, ": ");
             }
             sg.child(self.pat.make_segs(out, base_indent));

--- a/src/sg_statement.rs
+++ b/src/sg_statement.rs
@@ -109,7 +109,7 @@ fn new_sg_sig(out: &mut MakeSegsState, base_indent: &Alignment, sig: &Signature)
             prefix.push_str("extern ");
             if let Some(name) = &abi.name {
                 prefix.push_str(&name.to_token_stream().to_string());
-                prefix.push_str(" ");
+                prefix.push(' ');
             }
         }
         append_comments(out, base_indent, sg, sig.fn_token.span.start());
@@ -533,10 +533,7 @@ impl FormattableStmt for Item {
             Item::Impl(_) => (MarginGroup::BlockDef, true),
             Item::Macro(_) => (MarginGroup::BlockDef, true),
             Item::Macro2(_) => (MarginGroup::BlockDef, true),
-            Item::Mod(m) => (MarginGroup::BlockDef, match &m.content {
-                Some(_) => true,
-                None => false,
-            }),
+            Item::Mod(m) => (MarginGroup::BlockDef, m.content.is_some()),
             Item::Static(_) => (MarginGroup::None, false),
             Item::Struct(s) => (MarginGroup::BlockDef, match &s.fields {
                 syn::Fields::Named(_) => true,
@@ -695,7 +692,7 @@ impl Formattable for Item {
                             if bang.is_some() {
                                 sg.seg(out, "!");
                             }
-                            sg.child(build_path(out, base_indent, &base));
+                            sg.child(build_path(out, base_indent, base));
                             sg.seg(out, " for ");
                         }
                         sg.child(x.self_ty.make_segs(out, base_indent));
@@ -1050,7 +1047,7 @@ impl Formattable for Field {
                 append_comments(out, base_indent, &mut sg, n.span().start());
                 sg.seg(out, &format!("{}: ", n));
             }
-            sg.child((&self.ty).make_segs(out, base_indent));
+            sg.child(self.ty.make_segs(out, base_indent));
             sg.build(out)
         })
     }

--- a/src/sg_type.rs
+++ b/src/sg_type.rs
@@ -117,17 +117,11 @@ pub(crate) fn append_path<
         if i > 0 {
             node.split(out, indent.clone(), true);
         }
-        match prefix {
-            Some(d) => {
-                match d {
-                    Some(t) => {
-                        append_comments(out, base_indent, node, t);
-                    },
-                    None => { },
-                };
-                node.seg(out, "::");
-            },
-            None => { },
+        if let Some(d) = prefix {
+            if let Some(t) = d {
+                append_comments(out, base_indent, node, t);
+            };
+            node.seg(out, "::");
         }
         append_comments(out, base_indent, node, seg.value().ident.span().start());
         node.seg(out, &seg.value().ident.to_string());

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -11,7 +11,7 @@ fn rt(text: &str) {
         ..Default::default()
     }).unwrap();
     assert!(res.lost_comments.is_empty(), "Comments remain: {:?}", res.lost_comments);
-    assert!(text == &res.rendered, "Formatted text changed:\n\nBefore:\n{}\n\nAfter:\n{}\n", text, res.rendered);
+    assert!(text == res.rendered, "Formatted text changed:\n\nBefore:\n{}\n\nAfter:\n{}\n", text, res.rendered);
 }
 
 #[test]


### PR DESCRIPTION
Feel free to pick and choose some or none of these - happy to fix more of the lints bypassed by the allow if you like.

Also commented out some unused dependencies in the Cargo.toml.

`markdown` is also unmaintained. Might be worth looking into vendoring or moving to ` pulldown-cmark` as suggested in https://github.com/johannhof/markdown.rs/issues/25?

