### PR TITLE
Fully wrap parent if comments or attributes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -428,11 +428,16 @@ pub(crate) trait FormattableStmt: ToTokens + Formattable {
 
 pub trait Formattable {
     fn make_segs(&self, out: &mut MakeSegsState, base_indent: &Alignment) -> SplitGroupIdx;
+    fn has_attrs(&self) -> bool;
 }
 
 impl<F: Fn(&mut MakeSegsState, &Alignment) -> SplitGroupIdx> Formattable for F {
     fn make_segs(&self, line: &mut MakeSegsState, base_indent: &Alignment) -> SplitGroupIdx {
         self(line, base_indent)
+    }
+
+    fn has_attrs(&self) -> bool {
+        false
     }
 }
 
@@ -440,11 +445,19 @@ impl Formattable for Ident {
     fn make_segs(&self, out: &mut MakeSegsState, base_indent: &Alignment) -> SplitGroupIdx {
         new_sg_lit(out, Some((base_indent, self.span().start())), self)
     }
+
+    fn has_attrs(&self) -> bool {
+        false
+    }
 }
 
 impl Formattable for &Ident {
     fn make_segs(&self, out: &mut MakeSegsState, base_indent: &Alignment) -> SplitGroupIdx {
         (*self).make_segs(out, base_indent)
+    }
+
+    fn has_attrs(&self) -> bool {
+        false
     }
 }
 

--- a/src/sg_expr.rs
+++ b/src/sg_expr.rs
@@ -21,6 +21,7 @@ use crate::{
         new_sg_block,
         new_sg_macro,
         append_macro_body,
+        has_comments,
     },
     sg_type::{
         build_array_type,
@@ -169,6 +170,10 @@ fn new_sg_dotted(out: &mut MakeSegsState, base_indent: &Alignment, root: Dotted)
 impl Formattable for Expr {
     fn make_segs(&self, out: &mut MakeSegsState, base_indent: &Alignment) -> SplitGroupIdx {
         (&self).make_segs(out, base_indent)
+    }
+
+    fn has_attrs(&self) -> bool {
+        (&self).has_attrs()
     }
 }
 
@@ -582,7 +587,8 @@ impl Formattable for &Expr {
                 &e.attrs,
                 |out: &mut MakeSegsState, base_indent: &Alignment| {
                     let mut sg = new_sg(out);
-                    if check_split_brace_threshold(out, e.arms.len()) {
+                    if check_split_brace_threshold(out, e.arms.len()) ||
+                        e.arms.iter().any(|s| has_comments(out, s) || (s.pat.has_attrs() && out.split_attributes)) {
                         sg.initial_split();
                     }
                     append_comments(out, base_indent, &mut sg, e.match_token.span.start());
@@ -913,6 +919,52 @@ impl Formattable for &Expr {
             _ => unreachable!(),
         }
     }
+
+    fn has_attrs(&self) -> bool {
+        match self {
+            Expr::Array(x) => !x.attrs.is_empty(),
+            Expr::Assign(x) => !x.attrs.is_empty(),
+            Expr::AssignOp(x) => !x.attrs.is_empty(),
+            Expr::Async(x) => !x.attrs.is_empty(),
+            Expr::Await(x) => !x.attrs.is_empty(),
+            Expr::Binary(x) => !x.attrs.is_empty(),
+            Expr::Block(x) => !x.attrs.is_empty(),
+            Expr::Box(x) => !x.attrs.is_empty(),
+            Expr::Break(x) => !x.attrs.is_empty(),
+            Expr::Call(x) => !x.attrs.is_empty(),
+            Expr::Cast(x) => !x.attrs.is_empty(),
+            Expr::Closure(x) => !x.attrs.is_empty(),
+            Expr::Continue(x) => !x.attrs.is_empty(),
+            Expr::Field(x) => !x.attrs.is_empty(),
+            Expr::ForLoop(x) => !x.attrs.is_empty(),
+            Expr::Group(x) => !x.attrs.is_empty(),
+            Expr::If(x) => !x.attrs.is_empty(),
+            Expr::Index(x) => !x.attrs.is_empty(),
+            Expr::Let(x) => !x.attrs.is_empty(),
+            Expr::Lit(x) => !x.attrs.is_empty(),
+            Expr::Loop(x) => !x.attrs.is_empty(),
+            Expr::Macro(x) => !x.attrs.is_empty(),
+            Expr::Match(x) => !x.attrs.is_empty(),
+            Expr::MethodCall(x) => !x.attrs.is_empty(),
+            Expr::Paren(x) => !x.attrs.is_empty(),
+            Expr::Path(x) => !x.attrs.is_empty(),
+            Expr::Range(x) => !x.attrs.is_empty(),
+            Expr::Reference(x) => !x.attrs.is_empty(),
+            Expr::Repeat(x) => !x.attrs.is_empty(),
+            Expr::Return(x) => !x.attrs.is_empty(),
+            Expr::Struct(x) => !x.attrs.is_empty(),
+            Expr::Try(x) => !x.attrs.is_empty(),
+            Expr::TryBlock(x) => !x.attrs.is_empty(),
+            Expr::Tuple(x) => !x.attrs.is_empty(),
+            Expr::Type(x) => !x.attrs.is_empty(),
+            Expr::Unary(x) => !x.attrs.is_empty(),
+            Expr::Unsafe(x) => !x.attrs.is_empty(),
+            Expr::Verbatim(_) => false,
+            Expr::While(x) => !x.attrs.is_empty(),
+            Expr::Yield(x) => !x.attrs.is_empty(),
+            _ => unreachable!(),
+        }
+    }
 }
 
 impl Formattable for FieldValue {
@@ -936,5 +988,9 @@ impl Formattable for FieldValue {
             sg.child(self.expr.make_segs(out, base_indent));
             sg.build(out)
         })
+    }
+
+    fn has_attrs(&self) -> bool {
+        !self.attrs.is_empty()
     }
 }

--- a/src/sg_general.rs
+++ b/src/sg_general.rs
@@ -123,7 +123,8 @@ pub(crate) fn append_statement_list_raw(
     attrs: Option<&Vec<Attribute>>,
     block: &Vec<impl FormattableStmt>,
 ) {
-    if check_split_brace_threshold(out, block.len()) {
+    if check_split_brace_threshold(out, block.len()) ||
+        block.iter().any(|s| has_comments(out, s) || (s.has_attrs() && out.split_attributes)) {
         sg.initial_split();
     }
     sg.seg_unsplit(out, " ");

--- a/src/sg_general.rs
+++ b/src/sg_general.rs
@@ -171,6 +171,9 @@ pub(crate) fn append_bracketed_statement_list(
     stmts: &Vec<impl FormattableStmt>,
     end: LineColumn,
 ) {
+    if out.comments.contains_key(&HashLineColumn(end)) {
+        sg.initial_split();
+    }
     sg.seg(out, prefix);
     let indent = base_indent.indent();
     sg.split(out, indent.clone(), true);

--- a/src/sg_general_lists.rs
+++ b/src/sg_general_lists.rs
@@ -27,6 +27,7 @@ use crate::{
     },
     SplitGroupIdx,
     new_sg,
+    comments::HashLineColumn,
 };
 
 pub(crate) enum InlineListSuffix<T: Formattable> {
@@ -133,6 +134,9 @@ pub(crate) fn append_bracketed_list<
     suffix_start: LineColumn,
     suffix: &str,
 ) {
+    if out.comments.contains_key(&HashLineColumn(suffix_start)) {
+        sg.initial_split();
+    }
     append_comments(out, base_indent, sg, prefix_start);
     sg.seg(out, prefix);
     let need_pad = bracket_space && (!exprs.is_empty() || matches!(&list_suffix, InlineListSuffix::Extra(_)));

--- a/src/sg_general_lists.rs
+++ b/src/sg_general_lists.rs
@@ -10,6 +10,7 @@
 //!
 //! * curly bracketed: `{ a, b, c }` - inline within brackets with spaces
 use proc_macro2::LineColumn;
+use quote::ToTokens;
 use syn::{
     punctuated::Punctuated,
     Expr,
@@ -20,7 +21,10 @@ use crate::{
     MakeSegsState,
     Alignment,
     SplitGroupBuilder,
-    sg_general::append_comments,
+    sg_general::{
+        append_comments,
+        has_comments,
+    },
     SplitGroupIdx,
     new_sg,
 };
@@ -34,7 +38,7 @@ pub(crate) enum InlineListSuffix<T: Formattable> {
 }
 
 pub(crate) fn append_inline_list_raw<
-    E: Formattable,
+    E: Formattable + ToTokens,
     T: FormattablePunct,
     F: Formattable,
 >(
@@ -45,6 +49,9 @@ pub(crate) fn append_inline_list_raw<
     exprs: &Punctuated<E, T>,
     suffix: InlineListSuffix<F>,
 ) {
+    if exprs.pairs().any(|s| has_comments(out, s.value()) || (s.value().has_attrs() && out.split_attributes)) {
+        sg.initial_split();
+    }
     let mut next_punct: Option<&T> = None;
     for (i, pair) in exprs.pairs().enumerate() {
         if i > 0 {
@@ -93,7 +100,7 @@ pub(crate) fn append_inline_list_raw<
 }
 
 pub(crate) fn append_inline_list<
-    E: Formattable,
+    E: Formattable + ToTokens,
     T: FormattablePunct,
     F: Formattable,
 >(
@@ -110,7 +117,7 @@ pub(crate) fn append_inline_list<
 }
 
 pub(crate) fn append_bracketed_list<
-    E: Formattable,
+    E: Formattable + ToTokens,
     T: FormattablePunct,
     F: Formattable,
 >(
@@ -144,7 +151,7 @@ pub(crate) fn append_bracketed_list<
 }
 
 pub(crate) fn append_bracketed_list_common<
-    E: Formattable,
+    E: Formattable + ToTokens,
     T: FormattablePunct,
 >(
     out: &mut MakeSegsState,
@@ -172,7 +179,7 @@ pub(crate) fn append_bracketed_list_common<
 }
 
 pub(crate) fn append_bracketed_list_curly<
-    E: Formattable,
+    E: Formattable + ToTokens,
     T: FormattablePunct,
 >(
     out: &mut MakeSegsState,
@@ -190,7 +197,7 @@ pub(crate) fn append_bracketed_list_curly<
 }
 
 pub(crate) fn new_sg_bracketed_list<
-    E: Formattable,
+    E: Formattable + ToTokens,
     T: FormattablePunct,
     F: Formattable,
 >(
@@ -223,7 +230,7 @@ pub(crate) fn new_sg_bracketed_list<
 }
 
 pub(crate) fn new_sg_bracketed_list_common<
-    E: Formattable,
+    E: Formattable + ToTokens,
     T: FormattablePunct,
 >(
     out: &mut MakeSegsState,

--- a/src/sg_pat.rs
+++ b/src/sg_pat.rs
@@ -256,11 +256,37 @@ impl Formattable for &Pat {
             _ => unreachable!(),
         }
     }
+
+    fn has_attrs(&self) -> bool {
+        match self {
+            Pat::Box(x) => !x.attrs.is_empty(),
+            Pat::Ident(x) => !x.attrs.is_empty(),
+            Pat::Lit(x) => !x.attrs.is_empty(),
+            Pat::Macro(x) => !x.attrs.is_empty(),
+            Pat::Or(x) => !x.attrs.is_empty(),
+            Pat::Path(x) => !x.attrs.is_empty(),
+            Pat::Range(x) => !x.attrs.is_empty(),
+            Pat::Reference(x) => !x.attrs.is_empty(),
+            Pat::Rest(x) => !x.attrs.is_empty(),
+            Pat::Slice(x) => !x.attrs.is_empty(),
+            Pat::Struct(x) => !x.attrs.is_empty(),
+            Pat::Tuple(x) => !x.attrs.is_empty(),
+            Pat::TupleStruct(x) => !x.attrs.is_empty(),
+            Pat::Type(x) => !x.attrs.is_empty(),
+            Pat::Verbatim(_) => false,
+            Pat::Wild(x) => !x.attrs.is_empty(),
+            _ => unreachable!(),
+        }
+    }
 }
 
 impl Formattable for Pat {
     fn make_segs(&self, out: &mut MakeSegsState, base_indent: &Alignment) -> SplitGroupIdx {
         (&self).make_segs(out, base_indent)
+    }
+
+    fn has_attrs(&self) -> bool {
+        (&self).has_attrs()
     }
 }
 
@@ -279,5 +305,9 @@ impl Formattable for FieldPat {
             sg.child(self.pat.make_segs(out, base_indent));
             sg.build(out)
         })
+    }
+
+    fn has_attrs(&self) -> bool {
+        !self.attrs.is_empty()
     }
 }

--- a/src/sg_root.rs
+++ b/src/sg_root.rs
@@ -32,4 +32,8 @@ impl Formattable for File {
             build_inner(out, base_indent, self)
         }
     }
+
+    fn has_attrs(&self) -> bool {
+        !self.attrs.is_empty()
+    }
 }

--- a/src/sg_statement.rs
+++ b/src/sg_statement.rs
@@ -191,6 +191,15 @@ impl Formattable for Stmt {
             },
         }
     }
+
+    fn has_attrs(&self) -> bool {
+        match self {
+            Stmt::Local(l) => !l.attrs.is_empty(),
+            Stmt::Item(i) => i.has_attrs(),
+            Stmt::Expr(e) => e.has_attrs(),
+            Stmt::Semi(e, _) => e.has_attrs(),
+        }
+    }
 }
 
 impl FormattableStmt for ForeignItem {
@@ -266,6 +275,17 @@ impl Formattable for ForeignItem {
                 append_macro_body(out, base_indent, &mut sg, x.clone());
                 sg.build(out)
             },
+            _ => unreachable!(),
+        }
+    }
+
+    fn has_attrs(&self) -> bool {
+        match self {
+            ForeignItem::Fn(x) => !x.attrs.is_empty(),
+            ForeignItem::Static(x) => !x.attrs.is_empty(),
+            ForeignItem::Type(x) => !x.attrs.is_empty(),
+            ForeignItem::Macro(x) => !x.attrs.is_empty(),
+            ForeignItem::Verbatim(_) => false,
             _ => unreachable!(),
         }
     }
@@ -373,6 +393,17 @@ impl Formattable for ImplItem {
                 append_macro_body(out, base_indent, &mut sg, x.clone());
                 sg.build(out)
             },
+            _ => unreachable!(),
+        }
+    }
+
+    fn has_attrs(&self) -> bool {
+        match self {
+            ImplItem::Const(x) => !x.attrs.is_empty(),
+            ImplItem::Method(x) => !x.attrs.is_empty(),
+            ImplItem::Type(x) => !x.attrs.is_empty(),
+            ImplItem::Macro(x) => !x.attrs.is_empty(),
+            ImplItem::Verbatim(_) => false,
             _ => unreachable!(),
         }
     }
@@ -519,6 +550,17 @@ impl Formattable for TraitItem {
                 append_macro_body(out, base_indent, &mut sg, x.clone());
                 sg.build(out)
             },
+            _ => unreachable!(),
+        }
+    }
+
+    fn has_attrs(&self) -> bool {
+        match self {
+            TraitItem::Const(x) => !x.attrs.is_empty(),
+            TraitItem::Method(x) => !x.attrs.is_empty(),
+            TraitItem::Type(x) => !x.attrs.is_empty(),
+            TraitItem::Macro(x) => !x.attrs.is_empty(),
+            TraitItem::Verbatim(_) => false,
             _ => unreachable!(),
         }
     }
@@ -997,6 +1039,29 @@ impl Formattable for Item {
             _ => unreachable!(),
         }
     }
+
+    fn has_attrs(&self) -> bool {
+        match self {
+            Item::Const(x) => !x.attrs.is_empty(),
+            Item::Enum(x) => !x.attrs.is_empty(),
+            Item::ExternCrate(x) => !x.attrs.is_empty(),
+            Item::Fn(x) => !x.attrs.is_empty(),
+            Item::ForeignMod(x) => !x.attrs.is_empty(),
+            Item::Impl(x) => !x.attrs.is_empty(),
+            Item::Macro(x) => !x.attrs.is_empty(),
+            Item::Macro2(x) => !x.attrs.is_empty(),
+            Item::Mod(x) => !x.attrs.is_empty(),
+            Item::Static(x) => !x.attrs.is_empty(),
+            Item::Struct(x) => !x.attrs.is_empty(),
+            Item::Trait(x) => !x.attrs.is_empty(),
+            Item::TraitAlias(x) => !x.attrs.is_empty(),
+            Item::Type(x) => !x.attrs.is_empty(),
+            Item::Union(x) => !x.attrs.is_empty(),
+            Item::Use(x) => !x.attrs.is_empty(),
+            Item::Verbatim(_) => false,
+            _ => unreachable!(),
+        }
+    }
 }
 
 impl Formattable for Variant {
@@ -1040,6 +1105,10 @@ impl Formattable for Variant {
             sg.build(out)
         })
     }
+
+    fn has_attrs(&self) -> bool {
+        !self.attrs.is_empty()
+    }
 }
 
 impl Formattable for Field {
@@ -1054,6 +1123,10 @@ impl Formattable for Field {
             sg.child(self.ty.make_segs(out, base_indent));
             sg.build(out)
         })
+    }
+
+    fn has_attrs(&self) -> bool {
+        !self.attrs.is_empty()
     }
 }
 
@@ -1099,10 +1172,18 @@ impl Formattable for &UseTree {
         }
         sg.build(out)
     }
+
+    fn has_attrs(&self) -> bool {
+        false
+    }
 }
 
 impl Formattable for UseTree {
     fn make_segs(&self, out: &mut MakeSegsState, base_indent: &Alignment) -> SplitGroupIdx {
         (&self).make_segs(out, base_indent)
+    }
+
+    fn has_attrs(&self) -> bool {
+        (&self).has_attrs()
     }
 }

--- a/src/sg_type.rs
+++ b/src/sg_type.rs
@@ -299,6 +299,10 @@ impl Formattable for WherePredicate {
             ),
         }
     }
+
+    fn has_attrs(&self) -> bool {
+        false
+    }
 }
 
 impl Formattable for GenericParam {
@@ -357,6 +361,10 @@ impl Formattable for GenericParam {
             ),
         }
     }
+
+    fn has_attrs(&self) -> bool {
+        false
+    }
 }
 
 impl Formattable for TypeParamBound {
@@ -402,6 +410,10 @@ impl Formattable for TypeParamBound {
         }
         sg.build(out)
     }
+
+    fn has_attrs(&self) -> bool {
+        false
+    }
 }
 
 impl Formattable for LifetimeDef {
@@ -426,11 +438,19 @@ impl Formattable for LifetimeDef {
             node.build(out)
         })
     }
+
+    fn has_attrs(&self) -> bool {
+        !self.attrs.is_empty()
+    }
 }
 
 impl Formattable for syn::Lifetime {
     fn make_segs(&self, out: &mut MakeSegsState, base_indent: &Alignment) -> SplitGroupIdx {
         new_sg_lit(out, Some((base_indent, self.apostrophe.start())), self)
+    }
+
+    fn has_attrs(&self) -> bool {
+        false
     }
 }
 
@@ -582,11 +602,19 @@ impl Formattable for &Type {
             _ => unreachable!(),
         }
     }
+
+    fn has_attrs(&self) -> bool {
+        false
+    }
 }
 
 impl Formattable for Type {
     fn make_segs(&self, out: &mut MakeSegsState, base_indent: &Alignment) -> SplitGroupIdx {
         (&self).make_segs(out, base_indent)
+    }
+
+    fn has_attrs(&self) -> bool {
+        (&self).has_attrs()
     }
 }
 
@@ -602,6 +630,10 @@ impl Formattable for BareFnArg {
                 self.ty.make_segs(out, base_indent)
             }
         })
+    }
+
+    fn has_attrs(&self) -> bool {
+        !self.attrs.is_empty()
     }
 }
 
@@ -652,6 +684,13 @@ impl Formattable for FnArg {
             ),
         }
     }
+
+    fn has_attrs(&self) -> bool {
+        match self {
+            FnArg::Receiver(x) => !x.attrs.is_empty(),
+            FnArg::Typed(x) => !x.attrs.is_empty(),
+        }
+    }
 }
 
 impl Formattable for GenericArgument {
@@ -680,6 +719,10 @@ impl Formattable for GenericArgument {
             },
         }
     }
+
+    fn has_attrs(&self) -> bool {
+        false
+    }
 }
 
 impl Formattable for GenericMethodArgument {
@@ -689,10 +732,18 @@ impl Formattable for GenericMethodArgument {
             GenericMethodArgument::Const(c) => c.make_segs(out, base_indent),
         }
     }
+
+    fn has_attrs(&self) -> bool {
+        false
+    }
 }
 
 impl Formattable for &Path {
     fn make_segs(&self, out: &mut MakeSegsState, base_indent: &Alignment) -> SplitGroupIdx {
         build_path(out, base_indent, self)
+    }
+
+    fn has_attrs(&self) -> bool {
+        false
     }
 }

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -46,9 +46,13 @@ fn rt_struct1() {
 #[test]
 fn rt_struct_generic1() {
     rt(
-        r#"struct DefaultTupleStruct<A, B, C>(A, #[serde(default)]
-B, #[serde(default = "MyDefault::my_default")]
-C)
+        r#"struct DefaultTupleStruct<A, B, C>(
+    A,
+    #[serde(default)]
+    B,
+    #[serde(default = "MyDefault::my_default")]
+    C,
+)
 where
     C: MyDefault;
 "#,


### PR DESCRIPTION
Comments are always put on new lines, but the containing element doesn't necessarily get wrapped which looks a little strange and sometimes leaves end of line whitespace.

This wraps elements if any child has whitespace/config-wrapped attributes.