### PR TITLE
Reduce comment unordered list indentation

### DIFF
--- a/src/comments.rs
+++ b/src/comments.rs
@@ -533,7 +533,7 @@ fn recurse_write(state: &mut State, out: &mut String, line: LineState, node: &No
                         recurse_write(
                             state,
                             out,
-                            line.clone_indent(Some("* ".into()), "   ".into(), false),
+                            line.clone_indent(Some("* ".into()), "  ".into(), false),
                             child,
                             false,
                         );


### PR DESCRIPTION
I had used 3 space markdown indents because it's always safe, but it sounds like 2 spaces is okay for unordered lists per common mark spec and the discontinuity with 3 spaces sticks out badly.

This reduces it to two spaces.