### PR TITLE
Fix #48: New comment text breaking strategy to avoid breaking before punctuation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,6 +80,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "derive_more"
+version = "0.99.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
 name = "errno"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -107,6 +126,7 @@ dependencies = [
  "anyhow",
  "cargo-manifest",
  "clap",
+ "derive_more",
  "markdown",
  "proc-macro2",
  "quote",
@@ -288,6 +308,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.36.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -309,6 +338,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,4 @@ syn = { version = "1.0.107", features = ["full"] }
 walkdir = "2.3.2"
 threadpool = "1.8.1"
 cargo-manifest = "0.7.1"
+derive_more = "0.99.17"

--- a/tests/comments.rs
+++ b/tests/comments.rs
@@ -73,6 +73,13 @@ fn extract_end2() {
 }
 
 #[test]
+fn format_simple_wrapping1() {
+    let mut res = String::new();
+    format_md(&mut res, 10, None, "", "this is very long text").unwrap();
+    assert_eq!(res, "this is\nvery long\ntext");
+}
+
+#[test]
 fn format_split_link1() {
     let mut res = String::new();
     format_md(&mut res, 1000, None, "__", "![this is\na broken](https://example.com)").unwrap();
@@ -86,4 +93,11 @@ fn format_split_link2() {
 abcdabc](https://example.com)
 ").unwrap();
     assert_eq!(res, "__[abcdabcde abcdabc](https://example.com)");
+}
+
+#[test]
+fn format_split_punct_cross_inline1() {
+    let mut res = String::new();
+    format_md(&mut res, 10, None, "__", "abcd `abc`.").unwrap();
+    assert_eq!(res, "__abcd\n__`abc`.");
 }


### PR DESCRIPTION
This uses the strategy mentioned in the linked issue.

Right now splits are done on a per-leaf node basis with an implicit breakpoint before each node.  So if there's plain text followed by inline code then plain text:
```
hello this is `some code`.
```
the text can be split before `.` which is incorrect (in a round trip a new space would be added).

The new strategy basically keeps track of the last break point on a like while building the comment line, and if text is encountered that goes over the max line length without a break point inbetween, the previous break point can be used.

I'm surprised how little this broke, still waiting for the other shoe to drop.