### PR TITLE
Bump markdown to latest alpha and fix fn name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,9 +427,9 @@ dependencies = [
 
 [[package]]
 name = "markdown"
-version = "1.0.0-alpha.18"
+version = "1.0.0-alpha.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e61c5c85b392273c4d4ea546e6399ace3e3db172ab01b6de8f3d398d1dbd2ec"
+checksum = "a6491e6c702bf7e3b24e769d800746d5f2c06a6c6a2db7992612e0f429029e81"
 dependencies = [
  "unicode-id",
 ]

--- a/crates/genemichaels-lib/Cargo.toml
+++ b/crates/genemichaels-lib/Cargo.toml
@@ -8,7 +8,7 @@ repository.workspace = true
 readme.workspace = true
 
 [dependencies]
-markdown = { version = "1.0.0-alpha.12" }
+markdown = { version = "1.0.0-alpha.21" }
 proc-macro2 = { version = "1", features = ["span-locations"] }
 quote = "1"
 structre = "0.0"

--- a/crates/genemichaels-lib/src/whitespace.rs
+++ b/crates/genemichaels-lib/src/whitespace.rs
@@ -680,7 +680,7 @@ fn recurse_write(state: &mut State, out: &mut String, line: LineState, node: &No
                 recurse_write(state, out, line.clone_zero_indent(), child, false);
             }
         },
-        Node::BlockQuote(x) => {
+        Node::Blockquote(x) => {
             let line = line.clone_indent(None, "> ".into(), false);
             for (i, child) in x.children.iter().enumerate() {
                 if i > 0 {


### PR DESCRIPTION
---

I agree that when the request is merged I assign the copyright of the request to the repository owner.

The `markdown` dependency is specified as `markdown = { version = "1.0.0-alpha.12" }` which means trying to build the latest pulls in `1.0.0-alpha.21` and fails to build because fn rename `BlockQuote -> Blockquote`. Alternatively, we can just pin to exact version