### PR TITLE
New macro formatting getting clues from whitespace

### DIFF
--- a/crates/genemichaels-lib/src/lib.rs
+++ b/crates/genemichaels-lib/src/lib.rs
@@ -503,7 +503,7 @@ pub fn format_str(source: &str, config: &FormatConfig) -> Result<FormatRes, loga
     let shebang;
     let shebang_line_off;
     let source1;
-    if source.starts_with("#!") {
+    if source.starts_with("#!/") {
         let shebang_end = match source.find("\n") {
             Some(o) => o + 1,
             None => source.len(),

--- a/crates/genemichaels-lib/src/sg_general.rs
+++ b/crates/genemichaels-lib/src/sg_general.rs
@@ -515,7 +515,6 @@ pub(crate) fn append_macro_body(
                                     TokenTree::Ident(_) |
                                     TokenTree::Literal(_) => match p.as_char() {
                                         ':' => false,
-                                        '*' => false,
                                         _ => true,
                                     },
                                     TokenTree::Punct(prev_p) => prev_p.span().end() != p.span().start(),

--- a/crates/genemichaels-lib/src/whitespace.rs
+++ b/crates/genemichaels-lib/src/whitespace.rs
@@ -39,6 +39,9 @@ fn unicode_len(text: &str) -> VisualLen {
     VisualLen(text.chars().count())
 }
 
+/// Identifies the start/stop locations of whitespace in a chunk of source.
+/// Whitespace is grouped runs, but the `keep_max_blank_lines` parameter allows
+/// splitting the groups.
 pub fn extract_whitespaces(
     keep_max_blank_lines: usize,
     source: &str,
@@ -374,7 +377,12 @@ pub fn extract_whitespaces(
             ).map_err(
                 |e| loga::err_with(
                     "Error undoing syn parse transformations",
-                    ea!(line = e.span().start().line, column = e.span().start().column, error = e.to_string()),
+                    ea!(
+                        line = e.span().start().line,
+                        column = e.span().start().column,
+                        error = e.to_string(),
+                        source = source.lines().skip(e.span().start().line - 1).next().unwrap()
+                    ),
                 ),
             )?,
         );

--- a/crates/genemichaels-lib/tests/roundtrip.rs
+++ b/crates/genemichaels-lib/tests/roundtrip.rs
@@ -425,7 +425,22 @@ fn rt_self_type() {
 
 #[test]
 fn rt_skip_shebang() {
-    rt(r#"#!#[cfg(test)]
+    rt(r#"#!/bin/bash
 fn main() { }
 "#);
+}
+
+#[test]
+fn rt_dontskip_modattrs() {
+    rt(
+        r#"#![allow(
+    clippy::too_many_arguments,
+    clippy::field_reassign_with_default,
+    clippy::never_loop,
+    clippy::derive_hash_xor_eq
+)]
+
+fn main() { }
+"#,
+    );
 }

--- a/crates/genemichaels-lib/tests/roundtrip.rs
+++ b/crates/genemichaels-lib/tests/roundtrip.rs
@@ -104,8 +104,8 @@ fn rt_pat_field1() {
 
 #[test]
 fn rt_macro1() {
-    rt(r#"macro_rules! err(($l: expr, $($args: tt)*) => {
-    log!($l, slog::Level::Error, "", $($args)*)
+    rt(r#"macro_rules! err(($l: expr, $($args: tt) *) => {
+    log!($l, slog::Level::Error, "", $($args) *)
 });
 "#);
 }
@@ -138,7 +138,7 @@ fn rt_macro_star_equal() {
 
 #[test]
 fn rt_macro_star_equal_gt() {
-    rt(r#"x!(a* => b);
+    rt(r#"x!(a * => b);
 "#);
 }
 

--- a/crates/genemichaels-lib/tests/roundtrip.rs
+++ b/crates/genemichaels-lib/tests/roundtrip.rs
@@ -1,5 +1,4 @@
 #![cfg(test)]
-
 use genemichaels_lib::{
     format_str,
     FormatConfig,
@@ -105,8 +104,8 @@ fn rt_pat_field1() {
 
 #[test]
 fn rt_macro1() {
-    rt(r#"macro_rules! err(($l: expr, $($args: tt) *) => {
-    log!($l, slog::Level::Error, "", $($args) *)
+    rt(r#"macro_rules! err(($l: expr, $($args: tt)*) => {
+    log!($l, slog::Level::Error, "", $($args)*)
 });
 "#);
 }
@@ -134,6 +133,12 @@ fn rt_macro_blockcomma() {
 #[test]
 fn rt_macro_star_equal() {
     rt(r#"x!(a *= b);
+"#);
+}
+
+#[test]
+fn rt_macro_star_equal_gt() {
+    rt(r#"x!(a* => b);
 "#);
 }
 


### PR DESCRIPTION
Fix #100 

The original macro formatting determined if spaces should be added purely depending on the punctuation and some information carried over from the previous punctuation. This isn't sufficient to determine whether two pieces of punctuation need to be joined or separated.

For instance `*` `=` -- the previous method tried to make this `*=` but if the next symbol is `>` it should actually be `* =>`. The provided rust libraries (and macro processing) aren't powerful enough to determine this and the rust syntax is too ambiguous/complex.

The new processing relies on whitespace to determine if two subsequent punctuation tokens must be separated or joined.  I.e. if they were originally separated with space, they must not be separated with space.  When writing code, people will add spaces if to pieces of punctuation can't be joined, so this is a good alternate signal.

I tried to apply then the same logic for common cases: `.` typically pulls (non-punctuation) things together, `` ` `` typically begins a label so no space afterwards, `#` similarly (for `quote!()` macros).

I'm not sure how much this affects existing code, so I want to test it on a few codebases to try to reduce other unnecessary/undesired changes.

As an aside, I think I was originally hung up on determinism and whitespace - a deterministic formatter will produce the same output regardless of the initial formatting.  Basically the parsed token stream doesn't directly encode all significant whitespace, and I assumed that data model was complete and no additional whitespace was significant. The presence of whitespace is significant when reformatting raw token streams. Only the type and amount of whitespace is insignificant.

---

I agree that when the request is merged I assign the copyright of the request to the repository owner.
