### PR TITLE
Add flag to disable implicit markdown formatting for non-doc line comments

### DIFF
--- a/crates/genemichaels-lib/src/lib.rs
+++ b/crates/genemichaels-lib/src/lib.rs
@@ -43,6 +43,7 @@ pub mod utils;
 #[derive(PartialEq, Clone, Copy, Debug)]
 pub enum CommentMode {
     Normal,
+    ExplicitNormal,
     DocInner,
     DocOuter,
     Verbatim,
@@ -473,6 +474,7 @@ pub struct FormatConfig {
     pub comment_errors_fatal: bool,
     pub keep_max_blank_lines: usize,
     pub indent_spaces: usize,
+    pub explicit_markdown_comments: bool,
 }
 
 impl Default for FormatConfig {
@@ -487,6 +489,7 @@ impl Default for FormatConfig {
             comment_errors_fatal: false,
             keep_max_blank_lines: 0,
             indent_spaces: 4,
+            explicit_markdown_comments:false,
         }
     }
 }
@@ -791,12 +794,16 @@ pub fn format_ast(
                                     }
                                     let prefix = format!("{}//{} ", " ".repeat(b.get(&config)), match comment.mode {
                                         CommentMode::Normal => "",
+                                        CommentMode::ExplicitNormal => "?",
                                         CommentMode::DocInner => "!",
                                         CommentMode::DocOuter => "/",
                                         CommentMode::Verbatim => ".",
                                     });
                                     let verbatim = match comment.mode {
                                         CommentMode::Verbatim => {
+                                            true
+                                        },
+                                        CommentMode::Normal if config.explicit_markdown_comments => {
                                             true
                                         },
                                         _ => {

--- a/crates/genemichaels-lib/src/sg_general.rs
+++ b/crates/genemichaels-lib/src/sg_general.rs
@@ -447,7 +447,7 @@ pub(crate) fn append_macro_body(
                     };
                 }
 
-                // With exceptions, the default heterogenous adjacent token tree behavior is to
+                // With exceptions, the default heterogeneous adjacent token tree behavior is to
                 // push. For punctuation-adjacent, it depends on the punctuation type.
                 fn is_hetero_push_next(prev: &Option<TokenTree>) -> bool {
                     return match &prev {

--- a/crates/genemichaels-lib/src/whitespace.rs
+++ b/crates/genemichaels-lib/src/whitespace.rs
@@ -88,7 +88,7 @@ pub fn extract_whitespaces(
             let start_re =
                 &self
                     .start_re
-                    .get_or_insert_with(|| Regex::new(r#"(?:(//)(/|!|\.)?)|(/\*\*/)|(?:(/\*)(\*|!)?)"#).unwrap());
+                    .get_or_insert_with(|| Regex::new(r#"(?:(//)(/|!|\.|\?)?)|(/\*\*/)|(?:(/\*)(\*|!)?)"#).unwrap());
             let block_event_re =
                 &self.block_event_re.get_or_insert_with(|| Regex::new(r#"((?:/\*)|(?:\*/))"#).unwrap());
 
@@ -168,6 +168,7 @@ pub fn extract_whitespaces(
                                             "/" => CommentMode::DocOuter,
                                             "!" => CommentMode::DocInner,
                                             "." => CommentMode::Verbatim,
+                                            "?" => CommentMode::ExplicitNormal,
                                             _ => unreachable!(),
                                         }, start_suffix_match.end()),
                                         None => (CommentMode::Normal, start_prefix_match.end()),

--- a/crates/genemichaels-lib/tests/oneway.rs
+++ b/crates/genemichaels-lib/tests/oneway.rs
@@ -70,7 +70,8 @@ fn ow_dont_format_when_explicit_normal() {
     // Before/after newlines inconsequential
     owc(r#" 
 //  remove extra spaces"#, r#" 
-//  remove extra spaces"#, &FormatConfig {
+//  remove extra spaces
+"#, &FormatConfig {
         max_width: 120,
         explicit_markdown_comments: true,
         ..Default::default()

--- a/crates/genemichaels-lib/tests/oneway.rs
+++ b/crates/genemichaels-lib/tests/oneway.rs
@@ -1,30 +1,36 @@
-use genemichaels_lib::{
-    FormatConfig,
-    format_str,
+use {
+    genemichaels_lib::{
+        FormatConfig,
+        format_str,
+    },
 };
 
-fn ow(before: &str, want_after: &str) {
-    let res = format_str(before, &FormatConfig {
-        max_width: 120,
-        ..Default::default()
-    }).unwrap();
+fn owc(before: &str, want_after: &str, config: &FormatConfig) {
+    let res = format_str(before, config).unwrap();
     assert!(
         want_after == res.rendered,
         "Formatted text changed:\n\nWant after:\n{}\n\nAfter:\n{}\n",
         want_after
-            .lines()
+            .split("\n")
             .enumerate()
-            .map(|(line, text)| format!("{:>03} {}", line, text))
+            .map(|(line, text)| format!("{:>03} [{}]", line, text))
             .collect::<Vec<String>>()
             .join("\n"),
         res
             .rendered
-            .lines()
+            .split("\n")
             .enumerate()
-            .map(|(line, text)| format!("{:>03} {}", line, text))
+            .map(|(line, text)| format!("{:>03} [{}]", line, text))
             .collect::<Vec<String>>()
             .join("\n")
     );
+}
+
+fn ow(before: &str, want_after: &str) {
+    owc(before, want_after, &FormatConfig {
+        max_width: 120,
+        ..Default::default()
+    });
 }
 
 #[test]
@@ -48,4 +54,25 @@ fn ow_remove_blanks2() {
     x *= 2;
 }
 "#);
+}
+
+#[test]
+fn ow_format_explicit_normal() {
+    // Before/after newlines inconsequential
+    ow(r#" 
+//?  remove extra spaces"#, r#" 
+//? remove extra spaces
+"#);
+}
+
+#[test]
+fn ow_dont_format_when_explicit_normal() {
+    // Before/after newlines inconsequential
+    owc(r#" 
+//  remove extra spaces"#, r#" 
+//  remove extra spaces"#, &FormatConfig {
+        max_width: 120,
+        explicit_markdown_comments: true,
+        ..Default::default()
+    });
 }

--- a/readme_genemichaels.md
+++ b/readme_genemichaels.md
@@ -69,6 +69,10 @@ Here's the config file. All values shown are defaults and the keys can be omitte
   "keep_max_blank_lines": 0,
   // The number of spaces to indent by at each level.
   "indent_spaces": 4,
+  // `//` (plain line-comments) won't be treated implicitly as markdown. In this case you can
+  // use `//?` for explicitly markdown-formatted line-comments (these comments will work
+  // regardless of the setting)
+  "explicit_markdown_comments": false,
 }
 ```
 


### PR DESCRIPTION
Fix #103 

This adds the `explicit_markdown_comments` config option which disables implicit (normal) comment markdown formatting as well as the `//?` comment that's an explicitly markdown formatted comment (parallel to `//.` for an explicitly non-markdown formatted comment).

The above was added to the readme too.

---

I agree that when the request is merged I assign the copyright of the request to the repository owner.
