### PR TITLE
Support verbatim macros

### DIFF
--- a/crates/genemichaels-lib/src/lib.rs
+++ b/crates/genemichaels-lib/src/lib.rs
@@ -132,29 +132,35 @@ pub struct MakeSegsState {
     // manage externally (for now).
     /// Positive if processing within a macro, used to control macro tweaks.
     macro_depth: Rc<Cell<usize>>,
-    /// Original source text, used for verbatim output of quote macros.
-    source: Option<String>,
-    /// Byte offset of each line start in source, for span-to-offset conversion.
-    line_lookup: Vec<usize>,
+    /// Original source text and line-offset lookup, used for verbatim output of
+    /// quote macros. Present only when formatting from source text (not from AST alone).
+    source_map: Option<SourceMap>,
 }
 
-impl MakeSegsState {
+/// Pairs the original source text with a precomputed line-start byte-offset table,
+/// used to convert `proc_macro2::LineColumn` spans into byte offsets.
+pub(crate) struct SourceMap {
+    pub(crate) source: String,
+    /// Byte offset of each line start (0-indexed by line number − 1).
+    pub(crate) line_lookup: Vec<usize>,
+}
+
+impl SourceMap {
     pub(crate) fn source_offset(&self, loc: LineColumn) -> usize {
         if loc.line == 0 {
             return 0usize;
         }
         let line_start_offset = *self.line_lookup.get(loc.line - 1).unwrap();
-        let source = self.source.as_ref().unwrap();
 
         // loc.column is a 0-indexed character offset (not byte offset) in proc_macro2's
         // fallback tokenizer, so we must convert by walking characters to compute the
         // byte offset.
         let byte_offset: usize =
-            source[line_start_offset..]
+            self.source[line_start_offset..]
                 .char_indices()
                 .nth(loc.column)
                 .map(|(i, _)| i)
-                .unwrap_or(source.len() - line_start_offset);
+                .unwrap_or(self.source.len() - line_start_offset);
         line_start_offset + byte_offset
     }
 }
@@ -629,8 +635,10 @@ pub fn format_str(source: &str, config: &FormatConfig) -> Result<FormatRes, loga
             )?,
             config,
             whitespaces,
-            Some(source.to_string()),
-            line_lookup,
+            Some(SourceMap {
+                source: source.to_string(),
+                line_lookup,
+            }),
         )?;
     if let Some(shebang) = shebang {
         return Ok(FormatRes {
@@ -648,15 +656,14 @@ pub fn format_ast(
     config: &FormatConfig,
     whitespaces: BTreeMap<HashLineColumn, Vec<Whitespace>>,
 ) -> Result<FormatRes, loga::Error> {
-    format_ast_with_source(ast, config, whitespaces, None, vec![])
+    format_ast_with_source(ast, config, whitespaces, None)
 }
 
 fn format_ast_with_source(
     ast: impl Formattable,
     config: &FormatConfig,
     whitespaces: BTreeMap<HashLineColumn, Vec<Whitespace>>,
-    source: Option<String>,
-    line_lookup: Vec<usize>,
+    source_map: Option<SourceMap>,
 ) -> Result<FormatRes, loga::Error> {
     // Build text
     let mut out = MakeSegsState {
@@ -665,8 +672,7 @@ fn format_ast_with_source(
         whitespaces,
         config: config.clone(),
         macro_depth: Default::default(),
-        source,
-        line_lookup,
+        source_map,
     };
     let base_indent = Alignment(Rc::new(RefCell::new(Alignment_ {
         parent: None,

--- a/crates/genemichaels-lib/src/lib.rs
+++ b/crates/genemichaels-lib/src/lib.rs
@@ -141,9 +141,19 @@ impl MakeSegsState {
         if loc.line == 0 {
             return 0usize;
         }
-        let source = self.source.as_ref().unwrap();
         let line_start_offset = *self.line_lookup.get(loc.line - 1).unwrap();
-        line_start_offset + source[line_start_offset..].chars().take(loc.column).map(char::len_utf8).sum::<usize>()
+        let source = self.source.as_ref().unwrap();
+
+        // loc.column is a 0-indexed character offset (not byte offset) in proc_macro2's
+        // fallback tokenizer, so we must convert by walking characters to compute the
+        // byte offset.
+        let byte_offset: usize =
+            source[line_start_offset..]
+                .char_indices()
+                .nth(loc.column)
+                .map(|(i, _)| i)
+                .unwrap_or(source.len() - line_start_offset);
+        line_start_offset + byte_offset
     }
 }
 

--- a/crates/genemichaels-lib/src/lib.rs
+++ b/crates/genemichaels-lib/src/lib.rs
@@ -130,6 +130,21 @@ pub struct MakeSegsState {
     // manage externally (for now).
     /// Positive if processing within a macro, used to control macro tweaks.
     macro_depth: Rc<Cell<usize>>,
+    /// Original source text, used for verbatim output of quote macros.
+    source: Option<String>,
+    /// Byte offset of each line start in source, for span-to-offset conversion.
+    line_lookup: Vec<usize>,
+}
+
+impl MakeSegsState {
+    pub(crate) fn source_offset(&self, loc: LineColumn) -> usize {
+        if loc.line == 0 {
+            return 0usize;
+        }
+        let source = self.source.as_ref().unwrap();
+        let line_start_offset = *self.line_lookup.get(loc.line - 1).unwrap();
+        line_start_offset + source[line_start_offset..].chars().take(loc.column).map(char::len_utf8).sum::<usize>()
+    }
 }
 
 pub struct IncMacroDepth(Rc<Cell<usize>>);
@@ -156,7 +171,13 @@ pub(crate) fn line_length(out: &MakeSegsState, lines: &Lines, line_i: LineIdx) -
     for seg_i in &lines.owned_lines.get(line_i.0).unwrap().segs {
         let seg = out.segs.get(seg_i.0).unwrap();
         match &seg.content {
-            SegmentContent::Text(t) => len += t.chars().count(),
+            SegmentContent::Text(t) => {
+                // Only count characters up to the first newline (for verbatim multiline segments)
+                match t.find('\n') {
+                    Some(pos) => len += t[..pos].chars().count(),
+                    None => len += t.chars().count(),
+                }
+            },
             SegmentContent::Break(b, _) => {
                 if out.nodes.get(seg.node.0).unwrap().split {
                     len += out.config.indent_spaces * b.get().0;
@@ -559,8 +580,20 @@ pub fn format_str(source: &str, config: &FormatConfig) -> Result<FormatRes, loga
     }
     let source = source1;
     let (whitespaces, tokens) = extract_whitespaces(config.keep_max_blank_lines, source)?;
+    let line_lookup = {
+        let mut lookup = vec![];
+        let mut offset = 0usize;
+        loop {
+            lookup.push(offset);
+            offset += match source[offset..].find('\n') {
+                Some(r) => r,
+                None => break,
+            } + 1;
+        }
+        lookup
+    };
     let out =
-        format_ast(
+        format_ast_with_source(
             syn::parse2::<File>(
                 tokens,
             ).map_err(
@@ -571,6 +604,8 @@ pub fn format_str(source: &str, config: &FormatConfig) -> Result<FormatRes, loga
             )?,
             config,
             whitespaces,
+            Some(source.to_string()),
+            line_lookup,
         )?;
     if let Some(shebang) = shebang {
         return Ok(FormatRes {
@@ -588,6 +623,16 @@ pub fn format_ast(
     config: &FormatConfig,
     whitespaces: BTreeMap<HashLineColumn, Vec<Whitespace>>,
 ) -> Result<FormatRes, loga::Error> {
+    format_ast_with_source(ast, config, whitespaces, None, vec![])
+}
+
+fn format_ast_with_source(
+    ast: impl Formattable,
+    config: &FormatConfig,
+    whitespaces: BTreeMap<HashLineColumn, Vec<Whitespace>>,
+    source: Option<String>,
+    line_lookup: Vec<usize>,
+) -> Result<FormatRes, loga::Error> {
     // Build text
     let mut out = MakeSegsState {
         nodes: vec![],
@@ -595,6 +640,8 @@ pub fn format_ast(
         whitespaces,
         config: config.clone(),
         macro_depth: Default::default(),
+        source,
+        line_lookup,
     };
     let base_indent = Alignment(Rc::new(RefCell::new(Alignment_ {
         parent: None,

--- a/crates/genemichaels-lib/src/lib.rs
+++ b/crates/genemichaels-lib/src/lib.rs
@@ -98,8 +98,8 @@ pub(crate) struct SegmentLine {
 
 #[derive(Debug)]
 pub(crate) enum SegmentContent {
-    /// `preserve_leading_whitespace`: when true, the renderer will not trim
-    /// leading whitespace from this segment even at `seg_i == 1`.
+    /// `preserve_leading_whitespace`: when true, the renderer will not trim leading
+    /// whitespace from this segment even at `seg_i == 1`.
     Text(String, bool),
     Whitespace((Alignment, Vec<Whitespace>)),
     Break(Alignment, bool),
@@ -539,7 +539,7 @@ fn render_indent(config: &FormatConfig, current_indent: IndentLevel) -> String {
     }
 }
 
-#[derive(Debug, Copy, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(default)]
 pub struct FormatConfig {
     pub max_width: usize,
@@ -554,6 +554,9 @@ pub struct FormatConfig {
     /// Indent with spaces or tabs.
     pub indent_unit: IndentUnit,
     pub explicit_markdown_comments: bool,
+    /// Additional macro names (comma-separated) whose bodies should be kept verbatim
+    /// and not reformatted, like `quote!`.
+    pub verbatim_macro_names: String,
 }
 
 impl Default for FormatConfig {
@@ -570,6 +573,7 @@ impl Default for FormatConfig {
             indent_spaces: 4,
             indent_unit: IndentUnit::Spaces,
             explicit_markdown_comments: false,
+            verbatim_macro_names: String::new(),
         }
     }
 }

--- a/crates/genemichaels-lib/src/lib.rs
+++ b/crates/genemichaels-lib/src/lib.rs
@@ -98,7 +98,9 @@ pub(crate) struct SegmentLine {
 
 #[derive(Debug)]
 pub(crate) enum SegmentContent {
-    Text(String),
+    /// `preserve_leading_whitespace`: when true, the renderer will not trim
+    /// leading whitespace from this segment even at `seg_i == 1`.
+    Text(String, bool),
     Whitespace((Alignment, Vec<Whitespace>)),
     Break(Alignment, bool),
 }
@@ -181,7 +183,7 @@ pub(crate) fn line_length(out: &MakeSegsState, lines: &Lines, line_i: LineIdx) -
     for seg_i in &lines.owned_lines.get(line_i.0).unwrap().segs {
         let seg = out.segs.get(seg_i.0).unwrap();
         match &seg.content {
-            SegmentContent::Text(t) => {
+            SegmentContent::Text(t, _) => {
                 // Only count characters up to the first newline (for verbatim multiline segments)
                 match t.find('\n') {
                     Some(pos) => len += t[..pos].chars().count(),
@@ -380,7 +382,16 @@ impl SplitGroupBuilder {
             node: self.node,
             line: None,
             mode: SegmentMode::All,
-            content: SegmentContent::Text(text.to_string()),
+            content: SegmentContent::Text(text.to_string(), false),
+        });
+    }
+
+    pub(crate) fn seg_verbatim(&mut self, out: &mut MakeSegsState, text: impl ToString) {
+        self.add(out, Segment {
+            node: self.node,
+            line: None,
+            mode: SegmentMode::All,
+            content: SegmentContent::Text(text.to_string(), true),
         });
     }
 
@@ -389,7 +400,7 @@ impl SplitGroupBuilder {
             node: self.node,
             line: None,
             mode: SegmentMode::Split,
-            content: SegmentContent::Text(text.to_string()),
+            content: SegmentContent::Text(text.to_string(), false),
         });
     }
 
@@ -398,7 +409,7 @@ impl SplitGroupBuilder {
             node: self.node,
             line: None,
             mode: SegmentMode::Unsplit,
-            content: SegmentContent::Text(text.to_string()),
+            content: SegmentContent::Text(text.to_string(), false),
         });
     }
 
@@ -837,8 +848,8 @@ fn format_ast_with_source(
             for (seg_i, seg_mem_i) in segs.iter().enumerate() {
                 let seg = out.segs.get(seg_mem_i.0).unwrap();
                 match &seg.content {
-                    SegmentContent::Text(t) => {
-                        let t = if seg_i == 1 && line_i > 0 {
+                    SegmentContent::Text(t, preserve_leading_whitespace) => {
+                        let t = if seg_i == 1 && line_i > 0 && !preserve_leading_whitespace {
                             // Work around comments splitting lines at weird places (seg_i_i 0 == break,
                             // except on first line)
                             t.trim_start()

--- a/crates/genemichaels-lib/src/sg_general.rs
+++ b/crates/genemichaels-lib/src/sg_general.rs
@@ -337,12 +337,55 @@ pub(crate) fn append_macro_bracketed(
     }
 }
 
+fn is_quote_macro(path: &syn::Path) -> bool {
+    match path.segments.last() {
+        Some(seg) => {
+            let name = seg.ident.to_string();
+            name == "quote" || name == "quote_spanned"
+        },
+        None => false,
+    }
+}
+
+fn drain_whitespaces_in_range(out: &mut MakeSegsState, start: LineColumn, end: LineColumn) {
+    let start_key = HashLineColumn(start);
+    let end_key = HashLineColumn(end);
+    let keys: Vec<HashLineColumn> = out.whitespaces.range(start_key ..= end_key).map(|(k, _)| *k).collect();
+    for key in keys {
+        out.whitespaces.remove(&key);
+    }
+}
+
 pub(crate) fn new_sg_macro(
     out: &mut MakeSegsState,
     base_indent: &Alignment,
     mac: &Macro,
     semi: bool,
 ) -> SplitGroupIdx {
+    if is_quote_macro(&mac.path) && out.source.is_some() {
+        let mut sg = new_sg(out);
+
+        // Extract verbatim text for the entire macro invocation (path + ! + body) from
+        // source
+        let path_start = mac.path.segments.first().unwrap().ident.span().start();
+        let close_span = match &mac.delimiter {
+            syn::MacroDelimiter::Paren(x) => x.span.close(),
+            syn::MacroDelimiter::Brace(x) => x.span.close(),
+            syn::MacroDelimiter::Bracket(x) => x.span.close(),
+        };
+        let start = out.source_offset(path_start);
+        let end = out.source_offset(close_span.end());
+        let verbatim = out.source.as_ref().unwrap()[start .. end].to_string();
+        sg.seg(out, verbatim);
+
+        // Drain whitespace entries within the macro span to avoid lost_comments false
+        // positives
+        drain_whitespaces_in_range(out, path_start, close_span.end());
+        if semi {
+            sg.seg(out, ";");
+        }
+        return sg.build(out);
+    }
     let mut sg = new_sg(out);
     sg.child(build_path(out, base_indent, &mac.path));
     sg.seg(out, "!");

--- a/crates/genemichaels-lib/src/sg_general.rs
+++ b/crates/genemichaels-lib/src/sg_general.rs
@@ -337,11 +337,30 @@ pub(crate) fn append_macro_bracketed(
     }
 }
 
-fn is_quote_macro(path: &syn::Path) -> bool {
+fn is_quote_macro(path: &syn::Path, config: &crate::FormatConfig) -> bool {
     match path.segments.last() {
         Some(seg) => {
             let name = seg.ident.to_string();
-            name == "quote" || name == "quote_spanned"
+            if matches!(
+                name.as_str(),
+                // quote, genco, proc-quote, safe-quote, template-quote, squote, proc_macro::quote
+                "quote" | 
+                    // quote, proc-quote, safe-quote, template-quote
+                    "quote_spanned" | 
+                    // genco
+                    "quote_in" | 
+                    // quote_into
+                    "quote_into" | 
+                    // template-quote
+                    "quote_configured" | 
+                    // ts_quote
+                    "ts_quote" | 
+                    // quote-alias
+                    "quote_alias"
+            ) {
+                return true;
+            }
+            config.verbatim_macro_names.split(',').any(|n| n.trim() == name)
         },
         None => false,
     }
@@ -362,7 +381,7 @@ pub(crate) fn new_sg_macro(
     mac: &Macro,
     semi: bool,
 ) -> SplitGroupIdx {
-    if is_quote_macro(&mac.path) && out.source.is_some() {
+    if is_quote_macro(&mac.path, &out.config) && out.source.is_some() {
         let mut sg = new_sg(out);
 
         // Extract verbatim text for the entire macro invocation (path + ! + body) from
@@ -381,28 +400,31 @@ pub(crate) fn new_sg_macro(
             // Single-line macro (e.g. `quote!(expr)`), emit as one segment
             sg.seg(out, verbatim);
         } else {
-            // Multi-line macro: emit first line, then re-indent subsequent lines.
-            // Compute the indentation of the source line containing the macro
-            // invocation (i.e. leading whitespace count), NOT the column of the path
-            // itself (which may be further right if there's code before it on the line).
+            // Multi-line macro: emit first line, then re-indent subsequent lines. Compute the
+            // indentation of the source line containing the macro invocation (i.e. leading
+            // whitespace count), NOT the column of the path itself (which may be further
+            // right if there's code before it on the line).
             let source = out.source.as_ref().unwrap();
             let line_start = out.line_lookup[path_start.line - 1];
-            let orig_indent = source[line_start ..].chars().take_while(|c| *c == ' ' || *c == '\t').count();
+            let orig_indent = source[line_start..].chars().take_while(|c| *c == ' ' || *c == '\t').count();
             sg.seg(out, lines[0]);
-            for (i, line) in lines[1 ..].iter().enumerate() {
+            for (i, line) in lines[1..].iter().enumerate() {
                 let is_last = i == lines.len() - 2;
+
                 // Skip empty trailing line (from trailing newline)
                 if is_last && line.is_empty() {
                     break;
                 }
                 sg.split_always(out, base_indent.clone(), false);
+
                 // Empty/whitespace-only lines: just emit the break (no indent on blank lines)
                 if line.trim().is_empty() {
                     continue;
                 }
+
                 // Strip up to `orig_indent` chars of leading whitespace
                 let stripped = if line.len() > orig_indent {
-                    &line[orig_indent ..]
+                    &line[orig_indent..]
                 } else {
                     line.trim_start()
                 };

--- a/crates/genemichaels-lib/src/sg_general.rs
+++ b/crates/genemichaels-lib/src/sg_general.rs
@@ -381,7 +381,7 @@ pub(crate) fn new_sg_macro(
     mac: &Macro,
     semi: bool,
 ) -> SplitGroupIdx {
-    if is_quote_macro(&mac.path, &out.config) && out.source.is_some() {
+    if is_quote_macro(&mac.path, &out.config) && out.source_map.is_some() {
         let mut sg = new_sg(out);
 
         // Extract verbatim text for the entire macro invocation (path + ! + body) from
@@ -392,9 +392,10 @@ pub(crate) fn new_sg_macro(
             syn::MacroDelimiter::Brace(x) => x.span.close(),
             syn::MacroDelimiter::Bracket(x) => x.span.close(),
         };
-        let start = out.source_offset(path_start);
-        let end = out.source_offset(close_span.end());
-        let verbatim = out.source.as_ref().unwrap()[start .. end].to_string();
+        let sm = out.source_map.as_ref().unwrap();
+        let start = sm.source_offset(path_start);
+        let end = sm.source_offset(close_span.end());
+        let verbatim = sm.source[start .. end].to_string();
         let lines: Vec<&str> = verbatim.split('\n').collect();
         if lines.len() <= 1 {
             // Single-line macro (e.g. `quote!(expr)`), emit as one segment
@@ -404,9 +405,15 @@ pub(crate) fn new_sg_macro(
             // indentation of the source line containing the macro invocation (i.e. leading
             // whitespace count), NOT the column of the path itself (which may be further
             // right if there's code before it on the line).
-            let source = out.source.as_ref().unwrap();
-            let line_start = out.line_lookup[path_start.line - 1];
-            let orig_indent = source[line_start..].chars().take_while(|c| *c == ' ' || *c == '\t').count();
+            let sm = out.source_map.as_ref().unwrap();
+            let line_start = sm.line_lookup[path_start.line - 1];
+            let ws_chars = sm.source[line_start..].chars().take_while(|c| *c == ' ' || *c == '\t').count();
+            let orig_indent_bytes: usize =
+                sm.source[line_start..]
+                    .char_indices()
+                    .nth(ws_chars)
+                    .map(|(i, _)| i)
+                    .unwrap_or(sm.source.len() - line_start);
             sg.seg(out, lines[0]);
             for (i, line) in lines[1..].iter().enumerate() {
                 let is_last = i == lines.len() - 2;
@@ -422,9 +429,9 @@ pub(crate) fn new_sg_macro(
                     continue;
                 }
 
-                // Strip up to `orig_indent` chars of leading whitespace
-                let stripped = if line.len() > orig_indent {
-                    &line[orig_indent..]
+                // Strip up to `orig_indent_bytes` bytes of leading whitespace
+                let stripped = if line.len() > orig_indent_bytes {
+                    &line[orig_indent_bytes..]
                 } else {
                     line.trim_start()
                 };

--- a/crates/genemichaels-lib/src/sg_general.rs
+++ b/crates/genemichaels-lib/src/sg_general.rs
@@ -376,7 +376,39 @@ pub(crate) fn new_sg_macro(
         let start = out.source_offset(path_start);
         let end = out.source_offset(close_span.end());
         let verbatim = out.source.as_ref().unwrap()[start .. end].to_string();
-        sg.seg(out, verbatim);
+        let lines: Vec<&str> = verbatim.split('\n').collect();
+        if lines.len() <= 1 {
+            // Single-line macro (e.g. `quote!(expr)`), emit as one segment
+            sg.seg(out, verbatim);
+        } else {
+            // Multi-line macro: emit first line, then re-indent subsequent lines.
+            // Compute the indentation of the source line containing the macro
+            // invocation (i.e. leading whitespace count), NOT the column of the path
+            // itself (which may be further right if there's code before it on the line).
+            let source = out.source.as_ref().unwrap();
+            let line_start = out.line_lookup[path_start.line - 1];
+            let orig_indent = source[line_start ..].chars().take_while(|c| *c == ' ' || *c == '\t').count();
+            sg.seg(out, lines[0]);
+            for (i, line) in lines[1 ..].iter().enumerate() {
+                let is_last = i == lines.len() - 2;
+                // Skip empty trailing line (from trailing newline)
+                if is_last && line.is_empty() {
+                    break;
+                }
+                sg.split_always(out, base_indent.clone(), false);
+                // Empty/whitespace-only lines: just emit the break (no indent on blank lines)
+                if line.trim().is_empty() {
+                    continue;
+                }
+                // Strip up to `orig_indent` chars of leading whitespace
+                let stripped = if line.len() > orig_indent {
+                    &line[orig_indent ..]
+                } else {
+                    line.trim_start()
+                };
+                sg.seg_verbatim(out, stripped);
+            }
+        }
 
         // Drain whitespace entries within the macro span to avoid lost_comments false
         // positives

--- a/crates/genemichaels-lib/src/sg_statement.rs
+++ b/crates/genemichaels-lib/src/sg_statement.rs
@@ -842,6 +842,9 @@ impl Formattable for Item {
                 &x.attrs,
                 self.span(),
                 |out: &mut MakeSegsState, base_indent: &Alignment| {
+                    if x.ident.is_none() {
+                        return new_sg_macro(out, base_indent, &x.mac, x.semi_token.is_some());
+                    }
                     let mut sg = new_sg(out);
                     sg.child(build_path(out, base_indent, &x.mac.path));
                     sg.seg(out, "!");

--- a/crates/genemichaels-lib/tests/roundtrip.rs
+++ b/crates/genemichaels-lib/tests/roundtrip.rs
@@ -680,3 +680,32 @@ fn rt_quote_macro_unicode() {
 }
 "#);
 }
+
+#[test]
+fn rt_quote_macro_reindent() {
+    // Input where quote! is at a deeper indent than where the formatter will place it. The
+    // formatter should re-indent the body lines to match the new position.
+    let input = r#"fn main() {
+    let x = if true {
+            quote! {
+                #[serde(rename = #rename)]
+            }
+    };
+}
+"#;
+    let expected = r#"fn main() {
+    let x = if true {
+        quote! {
+            #[serde(rename = #rename)]
+        }
+    };
+}
+"#;
+    let res = format_str(input, &FormatConfig {
+        max_width: 120,
+        keep_max_blank_lines: 0,
+        ..Default::default()
+    }).unwrap();
+    assert!(res.lost_comments.is_empty(), "Comments remain: {:?}", res.lost_comments);
+    pretty_assertions::assert_str_eq!(expected, res.rendered);
+}

--- a/crates/genemichaels-lib/tests/roundtrip.rs
+++ b/crates/genemichaels-lib/tests/roundtrip.rs
@@ -740,3 +740,32 @@ fn rt_verbatim_macro_names_config() {
     // Sanity check: without the option the output differs (the macro was reformatted).
     assert_ne!(input, res_default.rendered, "Expected default formatting to differ from verbatim");
 }
+
+#[test]
+fn rt_verbatim_macro_names_item_position() {
+    // Item-position macros (top-level, outside any function) must also be kept
+    // verbatim when listed in `verbatim_macro_names`.
+    let input = r#"my_dsl! {
+    table person {
+        id: i64 [primary_key],
+        name: Option<String>,
+    }
+}
+"#;
+
+    let res_verbatim = format_str(input, &FormatConfig {
+        max_width: 120,
+        keep_max_blank_lines: 0,
+        verbatim_macro_names: "my_dsl".to_string(),
+        ..Default::default()
+    }).unwrap();
+    pretty_assertions::assert_str_eq!(input, res_verbatim.rendered);
+
+    // Sanity check: without the option the output differs.
+    let res_default = format_str(input, &FormatConfig {
+        max_width: 120,
+        keep_max_blank_lines: 0,
+        ..Default::default()
+    }).unwrap();
+    assert_ne!(input, res_default.rendered, "Expected default formatting to differ from verbatim");
+}

--- a/crates/genemichaels-lib/tests/roundtrip.rs
+++ b/crates/genemichaels-lib/tests/roundtrip.rs
@@ -683,8 +683,8 @@ fn rt_quote_macro_unicode() {
 
 #[test]
 fn rt_quote_macro_reindent() {
-    // Input where quote! is at a deeper indent than where the formatter will place it. The
-    // formatter should re-indent the body lines to match the new position.
+    // Input where quote! is at a deeper indent than where the formatter will place
+    // it. The formatter should re-indent the body lines to match the new position.
     let input = r#"fn main() {
     let x = if true {
             quote! {
@@ -708,4 +708,35 @@ fn rt_quote_macro_reindent() {
     }).unwrap();
     assert!(res.lost_comments.is_empty(), "Comments remain: {:?}", res.lost_comments);
     pretty_assertions::assert_str_eq!(expected, res.rendered);
+}
+
+#[test]
+fn rt_verbatim_macro_names_config() {
+    // A custom macro name supplied via `verbatim_macro_names` should be kept
+    // verbatim, just like the built-in quote macros.
+    let input = r#"fn main() {
+    my_dsl! {
+        hello world
+    };
+}
+"#;
+
+    // Without the config option the macro body would be reformatted.
+    let res_default = format_str(input, &FormatConfig {
+        max_width: 120,
+        keep_max_blank_lines: 0,
+        ..Default::default()
+    }).unwrap();
+
+    // With the config option the macro body should be kept verbatim.
+    let res_verbatim = format_str(input, &FormatConfig {
+        max_width: 120,
+        keep_max_blank_lines: 0,
+        verbatim_macro_names: "my_dsl".to_string(),
+        ..Default::default()
+    }).unwrap();
+    pretty_assertions::assert_str_eq!(input, res_verbatim.rendered);
+
+    // Sanity check: without the option the output differs (the macro was reformatted).
+    assert_ne!(input, res_default.rendered, "Expected default formatting to differ from verbatim");
 }

--- a/crates/genemichaels-lib/tests/roundtrip.rs
+++ b/crates/genemichaels-lib/tests/roundtrip.rs
@@ -658,3 +658,25 @@ fn rt_quote_spanned_macro() {
 }
 "#);
 }
+
+#[test]
+fn rt_quote_macro_nested() {
+    rt(r#"fn main() {
+    let tokens = quote::quote!{
+        let inner = quote::quote!{
+            #[derive(Debug)]
+            struct #name { }
+        };
+    };
+}
+"#);
+}
+
+#[test]
+fn rt_quote_macro_unicode() {
+    rt(r#"fn main() {
+    let héllo = "world";
+    let tokens = quote::quote!(fn résumé() -> String { #héllo });
+}
+"#);
+}

--- a/crates/genemichaels-lib/tests/roundtrip.rs
+++ b/crates/genemichaels-lib/tests/roundtrip.rs
@@ -60,8 +60,7 @@ fn rt_struct1() {
 
 #[test]
 fn rt_struct_generic1() {
-    rt(
-        r#"struct DefaultTupleStruct<A, B, C>(
+    rt(r#"struct DefaultTupleStruct<A, B, C>(
     A,
     #[serde(default)]
     B,
@@ -70,8 +69,7 @@ fn rt_struct_generic1() {
 )
 where
     C: MyDefault;
-"#,
-    );
+"#);
 }
 
 #[test]
@@ -133,14 +131,12 @@ fn rt_tuple_unit3() {
 
 #[test]
 fn rt_pat_field1() {
-    rt(
-        r#"fn main() {
+    rt(r#"fn main() {
     match x {
         Expr::MethodCall(ExprMethodCall { args, receiver: func, .. }) => { },
     }
 }
-"#,
-    )
+"#)
 }
 
 #[test]
@@ -214,14 +210,12 @@ static _x: i32 = 4i32;
 
 #[test]
 fn rt_comments_unbreakable_links1() {
-    rt(
-        r#"//! This is a very long line that will get wrapped right around check_store
+    rt(r#"//! This is a very long line that will get wrapped right around check_store
 //! [`check_store()`].
 //!
 //! [`check_store()`]: a::b::c
 fn main() { }
-"#,
-    );
+"#);
 }
 
 #[test]
@@ -345,8 +339,7 @@ fn rt_comment_before_label1() {
 #[test]
 fn rt_comment_x() {
     // https://github.com/andrewbaxter/genemichaels/issues/89
-    rt(
-        r#"fn get_valid_selection(get_actual_edit_transaction: impl Fn(
+    rt(r#"fn get_valid_selection(get_actual_edit_transaction: impl Fn(
     // current
     &Selection,
     // next
@@ -354,8 +347,7 @@ fn rt_comment_x() {
 ) -> anyhow::Result<EditTransaction>) -> anyhow::Result<Either<Selection, EditTransaction>> {
     todo!()
 }
-"#,
-    );
+"#);
 }
 
 #[test]
@@ -386,8 +378,7 @@ fn rt_comments_macro_comment() {
 
 #[test]
 fn rt_trait1() {
-    rt(
-        r#"pub trait MyTrait<T, D>: Sized
+    rt(r#"pub trait MyTrait<T, D>: Sized
 where
     T: MyTrait2,
     D: MyTrait3 {
@@ -395,8 +386,7 @@ where
     #[allow(clippy::needless_lifetimes)]
     fn another_method<'a>(&'a self) -> ReturnValue<T, D>;
 }
-"#,
-    );
+"#);
 }
 
 #[test]
@@ -417,12 +407,10 @@ where
 
 #[test]
 fn rt_empty_parens1() {
-    rt(
-        r#"fn main() {
+    rt(r#"fn main() {
     call_123456789_123456789_12346789_123456789_123456789_123456789_123456789_123456789_123456789_123456789_123456789();
 }
-"#,
-    );
+"#);
 }
 
 #[test]
@@ -519,8 +507,7 @@ fn main() { }
 
 #[test]
 fn rt_dontskip_modattrs() {
-    rt(
-        r#"#![allow(
+    rt(r#"#![allow(
     clippy::too_many_arguments,
     clippy::field_reassign_with_default,
     clippy::never_loop,
@@ -528,14 +515,12 @@ fn rt_dontskip_modattrs() {
 )]
 
 fn main() { }
-"#,
-    );
+"#);
 }
 
 #[test]
 fn rt_rustfmt_skip_all() {
-    rt(
-        r#"#![rustfmt::skip]
+    rt(r#"#![rustfmt::skip]
            fn main() {
     struct SomeStrangeIndentation {
  abcd: i32,
@@ -543,14 +528,12 @@ fn rt_rustfmt_skip_all() {
                (
                   )>}
 }
-"#,
-    );
+"#);
 }
 
 #[test]
 fn rt_rustfmt_skip_all_with_comments() {
-    rt(
-        r#"#![rustfmt::skip]
+    rt(r#"#![rustfmt::skip]
            fn main() {
     struct SomeStrangeIndentation {
  abcd: i32,
@@ -559,14 +542,12 @@ fn rt_rustfmt_skip_all_with_comments() {
                (
                   )>}
 }
-"#,
-    );
+"#);
 }
 
 #[test]
 fn rt_rustfmt_skip_subtree() {
-    rt(
-        r#"fn main() {
+    rt(r#"fn main() {
     #[rustfmt::skip]
     struct SomeStrangeIndentation {
  abcd: i32,
@@ -574,14 +555,12 @@ fn rt_rustfmt_skip_subtree() {
                (
                   )>}
 }
-"#,
-    );
+"#);
 }
 
 #[test]
 fn rt_rustfmt_skip_subtree_comment() {
-    rt(
-        r#"fn main() {
+    rt(r#"fn main() {
     #[rustfmt::skip]
     // Start comment
     struct SomeStrangeIndentation {
@@ -592,14 +571,12 @@ fn rt_rustfmt_skip_subtree_comment() {
                   )>}
     // End line end comment
 }
-"#,
-    );
+"#);
 }
 
 #[test]
 fn rt_rustfmt_skip_subtree_comment_array() {
-    rt(
-        r#"fn main() {
+    rt(r#"fn main() {
     #[rustfmt::skip]
     let src_attribs = [
         // EGL_WIDTH
@@ -618,14 +595,12 @@ fn rt_rustfmt_skip_subtree_comment_array() {
         egl::EGL_NONE,
      ];
 }
-"#,
-    );
+"#);
 }
 
 #[test]
 fn rttabs_struct_generic1() {
-    rt_tabs(
-        r#"struct DefaultTupleStruct<A, B, C>(
+    rt_tabs(r#"struct DefaultTupleStruct<A, B, C>(
 	A,
 	#[serde(default)]
 	B,
@@ -634,14 +609,52 @@ fn rttabs_struct_generic1() {
 )
 where
 	C: MyDefault;
-"#,
-    );
+"#);
 }
 
 #[test]
 fn rt_const_ref() {
     rt(r#"fn main() {
     (*&raw const X).x(text);
+}
+"#);
+}
+
+#[test]
+fn rt_quote_macro() {
+    rt(r#"fn main() {
+    let tokens = quote::quote!{
+        use openrpc_runtime::{self, jsonrpsee};
+
+        impl #name {
+            pub fn new<T: Into<String>>(value: T) -> Self {
+                Self(value.into())
+            }
+        }
+
+        // A comment inside quote
+        fn generated() -> Vec<u8> {
+            vec![1, 2, 3]
+        }
+    };
+}
+"#);
+}
+
+#[test]
+fn rt_quote_macro_paren() {
+    rt(r#"fn main() {
+    let tokens = quote::quote!(some_fn(#arg1, #arg2));
+}
+"#);
+}
+
+#[test]
+fn rt_quote_spanned_macro() {
+    rt(r#"fn main() {
+    let tokens = quote::quote_spanned!{span=>
+        #ident
+    };
 }
 "#);
 }


### PR DESCRIPTION
This pull request adds verbatim preservation for quote-style macros like `quote!`, `quote_spanned!` or `quote_in!`, as well as user supplied names during formatting. These macros contain quasi-quoted Rust with interpolation variables that aren't valid Rust syntax, so reformatting their bodies can produce broken output.

When the formatter encounters a recognized quote macro, it now extracts the original source text and re-emits it with adjusted indentation to match the surrounding context, rather than attempting to parse and reformat the body.

Resolves #127.

---

I agree that when the request is merged I assign the copyright of the request to the repository owner.
